### PR TITLE
Added SDK version info.

### DIFF
--- a/Classes/Managers/PlayKitManager.swift
+++ b/Classes/Managers/PlayKitManager.swift
@@ -10,6 +10,11 @@ import UIKit
 
 public class PlayKitManager: NSObject {
 
+    public static let versionString: String = Bundle.init(for: PlayKitManager.self)
+        .object(forInfoDictionaryKey: "CFBundleShortVersionString") as! String
+    
+    public static let clientTag = "playkit/ios-\(versionString)"
+    
     public static let sharedInstance : PlayKitManager = PlayKitManager()
     
     var pluginRegistry = Dictionary<String, PKPlugin.Type>()


### PR DESCRIPTION
PlayKitManager.versionString -- returns SDK version as specified in Podspec -- value of CFBundleShortVersionString.
PlayKitManager.clientTag -- return "playkit/ios-" + versionString, for use in certain APIs.


PlayKitManager.clientTag currently returns "playkit/ios-0.0.1".