### PR TITLE
FEM-1036, OTT Analytics: pause action displayed when media finished playing

### DIFF
--- a/Classes/Player/AVPlayerEngine.swift
+++ b/Classes/Player/AVPlayerEngine.swift
@@ -11,6 +11,8 @@ import AVFoundation
 import AVKit
 import CoreMedia
 
+/// An AVPlayerEngine is a controller used to manage the playback and timing of a media asset.
+/// It provides the interface to control the player’s behavior such as its ability to play, pause, and seek to various points in the timeline.
 class AVPlayerEngine : AVPlayer {
     
     // MARK: Player Properties
@@ -19,8 +21,8 @@ class AVPlayerEngine : AVPlayer {
     let assetKeysRequiredToPlay = [
         "playable",
         "tracks",
-        "hasProtectedContent",
-        ]
+        "hasProtectedContent"
+    ]
     
     private var avPlayerLayer: AVPlayerLayer!
     
@@ -29,6 +31,11 @@ class AVPlayerEngine : AVPlayer {
     private var isObserved: Bool = false
     private var tracksManager = TracksManager()
     private var lastBitrate: Double = 0
+    
+    /// Indicates whether the current items was played until the end.
+    ///
+    /// - note: Used for preventing 'pause' events to be sent after 'ended' event.
+    private var isPlayedToEndTime: Bool = false
     
     //  AVPlayerItem.currentTime() and the AVPlayerItem.timebase's rate are not KVO observable. We check their values regularly using this timer.
     private var nonObservablePropertiesUpdateTimer: Timer?
@@ -59,8 +66,10 @@ class AVPlayerEngine : AVPlayer {
             PKLog.trace("set currentPosition: \(currentPosition)")
 
             let newTime = rangeStart + CMTimeMakeWithSeconds(newValue, 1)
-            super.seek(to: newTime, toleranceBefore: kCMTimeZero, toleranceAfter: kCMTimeZero) { (isSeeked: Bool) in
+            super.seek(to: newTime, toleranceBefore: kCMTimeZero, toleranceAfter: kCMTimeZero) { [unowned self] (isSeeked: Bool) in
                 if isSeeked {
+                    // when seeked successfully reset player reached end time indicator
+                    self.isPlayedToEndTime = false
                     self.postEvent(event: PlayerEvents.seeked())
                     PKLog.trace("seeked")
                 } else {
@@ -342,6 +351,7 @@ class AVPlayerEngine : AVPlayer {
         let newState = PlayerState.idle
         self.postStateChange(newState: newState, oldState: self.currentState)
         self.currentState = newState
+        self.isPlayedToEndTime = true
         
         self.postEvent(event: PlayerEvents.ended())
     }
@@ -371,17 +381,11 @@ class AVPlayerEngine : AVPlayer {
         case #keyPath(currentItem.duration):
             event = PlayerEvents.durationChange(duration: CMTimeGetSeconds((self.currentItem?.duration)!))
         case #keyPath(rate):
-            if rate > 0 {
-                self.startOrResumeNonObservablePropertiesUpdateTimer()
-            } else {
-                self.nonObservablePropertiesUpdateTimer?.invalidate()
-                event = PlayerEvents.pause()
-            }
+            event = handleRate()
         case #keyPath(currentItem.status):
             event = self.handleStatusChange()
         case #keyPath(currentItem):
             self.handleItemChange()
-            
         default:
             super.observeValue(forKeyPath: keyPath, of: object, change: change, context: context)
         }
@@ -403,6 +407,25 @@ class AVPlayerEngine : AVPlayer {
             self.postStateChange(newState: newState, oldState: self.currentState)
             self.currentState = newState
         }
+    }
+    
+    
+    /// Handles change in player rate
+    ///
+    /// - Returns: The event to post, rate <= 0 means pause event.
+    private func handleRate() -> PKEvent? {
+        var event: PKEvent? = nil
+        
+        if rate > 0 {
+            self.startOrResumeNonObservablePropertiesUpdateTimer()
+        } else {
+            self.nonObservablePropertiesUpdateTimer?.invalidate()
+            // we don't want pause events to be sent when current item reached end.
+            if !isPlayedToEndTime {
+                event = PlayerEvents.pause()
+            }
+        }
+        return event
     }
     
     private func handleStatusChange() -> PKEvent? {
@@ -440,6 +463,8 @@ class AVPlayerEngine : AVPlayer {
         let newState = PlayerState.idle
         self.postStateChange(newState: newState, oldState: self.currentState)
         self.currentState = newState
+        // in case item changed reset player reached end time indicator
+        isPlayedToEndTime = false
     }
     
     private func postEvent(event: PKEvent?) {

--- a/Example/PlayKit.xcodeproj/project.pbxproj
+++ b/Example/PlayKit.xcodeproj/project.pbxproj
@@ -585,7 +585,7 @@
 			buildSettings = {
 				DEPLOYMENT_POSTPROCESSING = YES;
 				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
-				GCC_GENERATE_DEBUGGING_SYMBOLS = NO;
+				GCC_GENERATE_DEBUGGING_SYMBOLS = YES;
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"DEBUG=1",
 					"$(inherited)",
@@ -606,7 +606,7 @@
 			buildSettings = {
 				DEPLOYMENT_POSTPROCESSING = YES;
 				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
-				GCC_GENERATE_DEBUGGING_SYMBOLS = NO;
+				GCC_GENERATE_DEBUGGING_SYMBOLS = YES;
 				INFOPLIST_FILE = Tests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/Example/Tests/PlayerControllerTest.swift
+++ b/Example/Tests/PlayerControllerTest.swift
@@ -9,12 +9,13 @@
 import XCTest
 import PlayKit
 import SwiftyJSON
+import CoreMedia
 
 //Unit test to check the player controller
 //If somthing is break here we should raise a red flag - since this is our public API
 class PlayerControllerTest: XCTestCase {
-    var player : Player!
     
+    var player : Player!
     
     override func setUp() {
         super.setUp()
@@ -35,9 +36,7 @@ class PlayerControllerTest: XCTestCase {
         let media = MediaEntry(json: entry)
         config.set(mediaEntry: media)
         self.player = PlayKitManager.sharedInstance.loadPlayer(config:config)
-        
-        
-}
+    }
     
     override func tearDown() {
         super.tearDown()
@@ -52,8 +51,6 @@ class PlayerControllerTest: XCTestCase {
             } else {
                 XCTFail()
             }
-            
-            
         }
         waitForExpectations(timeout: 10.0) { (_) -> Void in}
     }
@@ -67,8 +64,6 @@ class PlayerControllerTest: XCTestCase {
             } else {
                 XCTFail()
             }
-            
-            
         }
         self.player.pause()
         waitForExpectations(timeout: 10.0) { (_) -> Void in}
@@ -95,7 +90,83 @@ class PlayerControllerTest: XCTestCase {
                 }
             }
         }
-       
         waitForExpectations(timeout: 10.0) { (_) -> Void in}
+    }
+    
+    /// Test a guard mechanism that prevents receiving pause events after ended event.
+    ///
+    /// ## The Flow:
+    /// 1. play the video.
+    /// 2. seek to 2 seconds before the end.
+    /// 3. on ended event pause the player.
+    ///
+    /// **expected result:** shouldn't receive the pause event and expectation should be fullfilled.
+    func testEnded() {
+        let asyncExpectation = expectation(description: "ended event")
+        var isEnded = false
+        var isFirstPlay = true
+        
+        player.play()
+        player.addObserver(self, events: [PlayerEvents.ended.self]) { info in
+            print("ended")
+            isEnded = true
+            self.player.pause()
+        }
+        self.player.addObserver(self, events: [PlayerEvents.playing.self, PlayerEvents.pause.self]) { info in
+            if info is PlayerEvents.playing && isFirstPlay && self.player.isPlaying {
+                isFirstPlay = false
+                // seek to end - 1 second
+                self.player.seek(to: CMTimeMake(Int64(self.player.duration - 2), 1))
+            }
+            // should not fire play/pause after ended
+            if isEnded {
+                XCTFail()
+            }
+        }
+        DispatchQueue.main.asyncAfter(deadline: .now() + 9) {
+            asyncExpectation.fulfill()
+        }
+        waitForExpectations(timeout: 10, handler: nil)
+    }
+    
+    /// Test to make sure pause/play events are received after ended + seeked event.
+    ///
+    /// ## The Flow:
+    /// 1. play the video.
+    /// 2. seek to 2 seconds before the end.
+    /// 3. on ended event seek again to 2 seconds before the end.
+    /// 4. play again
+    /// 
+    /// **expected result:** receive play event after ended + seeked
+    func testAnalyticsEndedSeekedPlayed() {
+        let asyncExpectation = expectation(description: "ended -> seek -> play events")
+        var isEnded = false
+        var isFirstPlay = true
+        var isSeekedAfterEnded = false
+        
+        player.play()
+        player.addObserver(self, events: [PlayerEvents.ended.self]) { info in
+            print("ended")
+            isEnded = true
+            self.player.seek(to: CMTimeMake(Int64(self.player.duration - 2), 1))
+        }
+        player.addObserver(self, events: [PlayerEvents.playing.self, PlayerEvents.pause.self]) { info in
+            if info is PlayerEvents.playing && isFirstPlay && self.player.isPlaying {
+                isFirstPlay = false
+                // seek to end - 2 second
+                self.player.seek(to: CMTimeMake(Int64(self.player.duration - 2), 1))
+            }
+            // should fire play/pause after ended + seeked
+            if isSeekedAfterEnded {
+                asyncExpectation.fulfill()
+            }
+        }
+        player.addObserver(self, events: [PlayerEvents.seeked.self]) { info in
+            if isEnded {
+                isSeekedAfterEnded = true
+                self.player.play()
+            }
+        }
+        waitForExpectations(timeout: 20, handler: nil)
     }
 }


### PR DESCRIPTION
* Fixed issue where pause event would fire even after media finished playing.