### PR TITLE
FEM-1035 wrong actions on app launch

### DIFF
--- a/Classes/Managers/PlayKitManager.swift
+++ b/Classes/Managers/PlayKitManager.swift
@@ -28,7 +28,7 @@ public class PlayKitManager: NSObject {
     
     /// Loads and returns a player object using a provided configuration.
     ///
-    /// - Important: In order to start buffering the video after loading the player 
+    /// - Important: In order to start buffering the video after loading the player
     /// you must call prepare on the player with the same configuration.
     /// ````
     ///     player = PlayKitManager.sharedInstance.loadPlayer(config: config)

--- a/Classes/Managers/PlayKitManager.swift
+++ b/Classes/Managers/PlayKitManager.swift
@@ -8,6 +8,12 @@
 
 import UIKit
 
+
+/**
+ Manager class used for:
+  - creating `Player` objects.
+  - creating and registering plugins.
+ */
 public class PlayKitManager: NSObject {
 
     public static let versionString: String = Bundle.init(for: PlayKitManager.self)
@@ -19,6 +25,18 @@ public class PlayKitManager: NSObject {
     
     var pluginRegistry = Dictionary<String, PKPlugin.Type>()
     
+    
+    /// Loads and returns a player object using a provided configuration.
+    ///
+    /// - Important: In order to start buffering the video after loading the player 
+    /// you must call prepare on the player with the same configuration.
+    /// ````
+    ///     player = PlayKitManager.sharedInstance.loadPlayer(config: config)
+    ///     player.prepare(config)
+    /// ````
+    ///
+    /// - Parameter config: The configuration object to load the player with.
+    /// - Returns: A player loaded using the provided configuration.
     public func loadPlayer(config: PlayerConfig) -> Player {
         let loader = PlayerLoader()
         loader.load(config)

--- a/Classes/Player/PlayerConfig.swift
+++ b/Classes/Player/PlayerConfig.swift
@@ -8,6 +8,7 @@
 
 import Foundation
 
+/// A `PlayerConfig` object defines behavior and info to use when loading a `Player` object.
 public class PlayerConfig: NSObject {
     public var mediaEntry : MediaEntry?
     public var startTime : TimeInterval = 0

--- a/Classes/Player/PlayerLoader.swift
+++ b/Classes/Player/PlayerLoader.swift
@@ -56,7 +56,6 @@ class PlayerLoader: PlayerDecoratorBase {
                 }
             }
             setPlayer(player)
-            playerController.prepare(config)
         }
     }
     

--- a/Example/Tests/MessegeBusTest.swift
+++ b/Example/Tests/MessegeBusTest.swift
@@ -33,8 +33,7 @@ class MessegeBusTest: XCTestCase {
         let media = MediaEntry(json: entry)
         config.set(mediaEntry: media)
         self.player = PlayKitManager.sharedInstance.loadPlayer(config:config)
-        
-        
+        self.player.prepare(config)
     }
     
     override func tearDown() {

--- a/Example/Tests/PlayerControllerTest.swift
+++ b/Example/Tests/PlayerControllerTest.swift
@@ -35,8 +35,7 @@ class PlayerControllerTest: XCTestCase {
         let media = MediaEntry(json: entry)
         config.set(mediaEntry: media)
         self.player = PlayKitManager.sharedInstance.loadPlayer(config:config)
-        
-        
+        self.player.prepare(config)
 }
     
     override func tearDown() {

--- a/Plugins/Phoenix/KalturaPluginManager.swift
+++ b/Plugins/Phoenix/KalturaPluginManager.swift
@@ -8,7 +8,7 @@
 
 import UIKit
 
-internal enum PhoenixAnalyticsType: String {
+enum PhoenixAnalyticsType: String {
     case hit
     case play
     case stop
@@ -25,7 +25,7 @@ protocol KalturaPluginManagerDelegate {
     func pluginManagerDidSendAnalyticsEvent(action: PhoenixAnalyticsType)
 }
 
-internal class KalturaPluginManager {
+final class KalturaPluginManager {
 
     public var delegate: KalturaPluginManagerDelegate?
     
@@ -48,7 +48,6 @@ internal class KalturaPluginManager {
         }
         
         registerToAllEvents()
-
     }
     
     public func destroy() {
@@ -58,30 +57,34 @@ internal class KalturaPluginManager {
     }
     
     func registerToAllEvents() {
-        
-        
-        self.messageBus?.addObserver(self, events: [PlayerEvents.ended.self], block: { (info) in
+        PKLog.trace("Register to all events")
+        guard let messageBus = self.messageBus else {
+            PKLog.error("messageBus is nil !")
+            return
+        }
+
+        messageBus.addObserver(self, events: [PlayerEvents.ended.self], block: { (info) in
             PKLog.trace("ended info: \(info)")
             self.stopTimer()
             self.delegate?.pluginManagerDidSendAnalyticsEvent(action: .finish)
         })
         
-        self.messageBus?.addObserver(self, events: [PlayerEvents.error.self], block: { (info) in
+        messageBus.addObserver(self, events: [PlayerEvents.error.self], block: { (info) in
             PKLog.trace("error info: \(info)")
             self.delegate?.pluginManagerDidSendAnalyticsEvent(action: .error)
         })
         
-        self.messageBus?.addObserver(self, events: [PlayerEvents.pause.self], block: { (info) in
+        messageBus.addObserver(self, events: [PlayerEvents.pause.self], block: { (info) in
             PKLog.trace("pause info: \(info)")
             self.delegate?.pluginManagerDidSendAnalyticsEvent(action: .pause)
         })
         
-        self.messageBus?.addObserver(self, events: [PlayerEvents.loadedMetadata.self], block: { (info) in
+        messageBus.addObserver(self, events: [PlayerEvents.loadedMetadata.self], block: { (info) in
             PKLog.trace("loadedMetadata info: \(info)")
             self.delegate?.pluginManagerDidSendAnalyticsEvent(action: .load)
         })
         
-        self.messageBus?.addObserver(self, events: [PlayerEvents.loadedMetadata.self], block: { (info) in
+        messageBus.addObserver(self, events: [PlayerEvents.playing.self], block: { (info) in
             PKLog.trace("play info: \(info)")
             
             if !self.intervalOn {
@@ -95,10 +98,7 @@ internal class KalturaPluginManager {
             } else {
                 self.delegate?.pluginManagerDidSendAnalyticsEvent(action: .play);
             }
-            
-            
         })
-        
     }
     
     private func createTimer() {


### PR DESCRIPTION
* Separated `prepare()` function from load. to use player and start buffering immediately now using load + prepare separately.
* Added documentation.

first play issue was solved in FEM-1027