### PR TITLE
Config API change and PKPlugin

### DIFF
--- a/Classes/Managers/PlayKitManager.swift
+++ b/Classes/Managers/PlayKitManager.swift
@@ -37,9 +37,9 @@ public class PlayKitManager: NSObject {
     ///
     /// - Parameter config: The configuration object to load the player with.
     /// - Returns: A player loaded using the provided configuration.
-    public func loadPlayer(config: PlayerConfig) -> Player {
+    public func loadPlayer(pluginConfig: PluginConfig?) -> Player {
         let loader = PlayerLoader()
-        loader.load(config)
+        loader.load(pluginConfig: pluginConfig)
         return loader
     }
     

--- a/Classes/Managers/PlayKitManager.swift
+++ b/Classes/Managers/PlayKitManager.swift
@@ -16,6 +16,11 @@ import UIKit
  */
 public class PlayKitManager: NSObject {
 
+    // private init to prevent initializing this singleton
+    private override init() {
+        super.init()
+    }
+    
     public static let versionString: String = Bundle(for: PlayKitManager.self)
         .object(forInfoDictionaryKey: "CFBundleShortVersionString") as! String
     

--- a/Classes/Managers/PlayKitManager.swift
+++ b/Classes/Managers/PlayKitManager.swift
@@ -16,12 +16,12 @@ import UIKit
  */
 public class PlayKitManager: NSObject {
 
-    public static let versionString: String = Bundle.init(for: PlayKitManager.self)
+    public static let versionString: String = Bundle(for: PlayKitManager.self)
         .object(forInfoDictionaryKey: "CFBundleShortVersionString") as! String
     
     public static let clientTag = "playkit/ios-\(versionString)"
     
-    public static let sharedInstance : PlayKitManager = PlayKitManager()
+    @objc(sharedInstance) public static let shared: PlayKitManager = PlayKitManager()
     
     var pluginRegistry = Dictionary<String, PKPlugin.Type>()
     
@@ -47,11 +47,11 @@ public class PlayKitManager: NSObject {
         pluginRegistry[pluginClass.pluginName] = pluginClass
     }
     
-    func createPlugin(name: String) -> PKPlugin? {
+    func createPlugin(name: String, player: Player, pluginConfig: Any?, messageBus: MessageBus) -> PKPlugin? {
         let pluginClass = pluginRegistry[name]
         guard pluginClass != nil else {
             return nil
         }
-        return pluginClass?.init()
+        return pluginClass?.init(player: player, pluginConfig: pluginConfig, messageBus: messageBus)
     }
 }

--- a/Classes/MessageBus.swift
+++ b/Classes/MessageBus.swift
@@ -14,7 +14,7 @@ private struct Observation {
 }
 
 public class MessageBus: NSObject {
-    private var observations = [String: [Observation]]()
+    private var observations = [String : [Observation]]()
     private let lock: AnyObject = UUID().uuidString as AnyObject
     
     public func addObserver(_ observer: AnyObject, events: [PKEvent.Type], block: @escaping (PKEvent)->Void) {
@@ -48,10 +48,10 @@ public class MessageBus: NSObject {
     }
     
     public func post(_ event: PKEvent) {
-        DispatchQueue.main.async { [unowned self] in
+        DispatchQueue.main.async { [weak self] in
             let typeId = NSStringFromClass(type(of:event))
             // TODO: remove nil observers
-            if let array = self.observations[typeId] {
+            if let array = self?.observations[typeId] {
                 array.forEach {
                     if $0.self.observer != nil {
                         $0.block(event)

--- a/Classes/Player/AVPlayerEngine.swift
+++ b/Classes/Player/AVPlayerEngine.swift
@@ -31,6 +31,7 @@ class AVPlayerEngine: AVPlayer {
     private var isObserved: Bool = false
     private var tracksManager = TracksManager()
     private var lastBitrate: Double = 0
+    private var isDestroyed = false
     
     /// Indicates whether the current items was played until the end.
     ///
@@ -169,7 +170,9 @@ class AVPlayerEngine: AVPlayer {
     }
     
     deinit {
-        self.destroy()
+        if !isDestroyed {
+            self.destroy()
+        }
     }
     
     private func startOrResumeNonObservablePropertiesUpdateTimer() {
@@ -214,6 +217,7 @@ class AVPlayerEngine: AVPlayer {
         self.onEventBlock = nil
         // removes app state observer
         AppStateSubject.sharedInstance.remove(observer: self)
+        self.isDestroyed = true
     }
     
     @available(iOS 9.0, *)
@@ -324,8 +328,9 @@ class AVPlayerEngine: AVPlayer {
             removeObserver(self, forKeyPath: keyPath, context: &observerContext)
         }
         
+        NotificationCenter.default.removeObserver(self, name: NSNotification.Name.AVPlayerItemFailedToPlayToEndTime, object: nil)
+        NotificationCenter.default.removeObserver(self, name: NSNotification.Name.AVPlayerItemDidPlayToEndTime, object: nil)
         NotificationCenter.default.removeObserver(self, name: NSNotification.Name.AVPlayerItemNewAccessLogEntry, object: nil)
-        NotificationCenter.default.removeObserver(self)
     }
     
     func onAccessLogEntryNotification(notification: Notification) {

--- a/Classes/Player/AVPlayerEngine.swift
+++ b/Classes/Player/AVPlayerEngine.swift
@@ -13,7 +13,7 @@ import CoreMedia
 
 /// An AVPlayerEngine is a controller used to manage the playback and timing of a media asset.
 /// It provides the interface to control the player’s behavior such as its ability to play, pause, and seek to various points in the timeline.
-class AVPlayerEngine : AVPlayer {
+class AVPlayerEngine: AVPlayer {
     
     // MARK: Player Properties
     
@@ -107,7 +107,6 @@ class AVPlayerEngine : AVPlayer {
     public var isPlaying: Bool {
         guard let currentItem = self.currentItem else {
             PKLog.error("current item is empty")
-            
             return false
         }
         

--- a/Classes/Player/MediaEntry.swift
+++ b/Classes/Player/MediaEntry.swift
@@ -64,7 +64,7 @@ public class MediaEntry: NSObject {
     }
     
     override public var description: String {
-        get{
+        get {
             return "id : \(self.id), sources: \(self.sources)"
         }
     }
@@ -150,7 +150,7 @@ public class MediaSource: NSObject {
     }
     
     override public var description: String {
-        get{
+        get {
             return "id : \(self.id), url: \(self.contentUrl)"
         }
     }

--- a/Classes/Player/Player.swift
+++ b/Classes/Player/Player.swift
@@ -37,7 +37,7 @@ import AVKit
     /**
      Get the player's duration.
      */
-    var duration: Double { get }
+    var duration: TimeInterval { get }
     
     var currentAudioTrack: String? { get }
     
@@ -47,7 +47,7 @@ import AVKit
      Prepare for playing an entry.
      play when it's ready.
      */
-    func prepare(_ config: PlayerConfig)
+    func prepare(_ config: MediaConfig)
     
     /**
      Convenience method for setting shouldPlayWhenReady to true.
@@ -66,7 +66,7 @@ import AVKit
     /**
      Prepare for playing the next entry.      
     */
-    func prepareNext(_ config: PlayerConfig) -> Bool
+    func prepareNext(_ config: MediaConfig) -> Bool
 
     /**
      Load the entry that was prepared with prepareNext(), without waiting for the current entry to end.

--- a/Classes/Player/PlayerConfig.swift
+++ b/Classes/Player/PlayerConfig.swift
@@ -8,10 +8,25 @@
 
 import Foundation
 
-/// A `PlayerConfig` object defines behavior and info to use when loading a `Player` object.
+/// A `PlayerConfig` object defines mediaConfig and pluginConfig composite object.
 public class PlayerConfig: NSObject {
-    public var mediaEntry : MediaEntry?
-    public var startTime : TimeInterval = 0
+    public var mediaConfig = MediaConfig()
+    public var pluginConfig = PluginConfig()
+    
+    public init(mediaConfig: MediaConfig, pluginConfig: PluginConfig) {
+        self.mediaConfig = mediaConfig
+        self.pluginConfig = pluginConfig
+    }
+}
+
+/// A `MediaConfig` object defines behavior and info to use when preparing a `Player` object.
+public class MediaConfig: NSObject {
+    public var mediaEntry: MediaEntry?
+    public var startTime: TimeInterval = 0
+    
+    override public var description: String {
+        return "Media config, mediaEntry: \(self.mediaEntry)\nstartTime: \(self.startTime)"
+    }
     
     // Builders
     @discardableResult
@@ -27,15 +42,19 @@ public class PlayerConfig: NSObject {
     }
 }
 
+/// A `PluginConfig` object defines config to use when loading a plugin object.
 public class PluginConfig: NSObject {
-    public var config = [String : AnyObject]()
-    subscript(idx: String) -> AnyObject? {
-        get {
-            return self.config[idx]
-        }
-        set {
-            self.config[idx] = newValue
-        }
+    /// Plugins congfig dictionary holds [plugin name : plugin config]
+    public var config: [String : AnyObject]?
+    
+    @discardableResult
+    public func set(config: [String : AnyObject]) -> Self {
+        self.config = config
+        return self
+    }
+    
+    override public var description: String {
+        return "Plugin config:\n\(self.config)"
     }
 }
 

--- a/Classes/Player/PlayerConfig.swift
+++ b/Classes/Player/PlayerConfig.swift
@@ -12,10 +12,6 @@ import Foundation
 public class PlayerConfig: NSObject {
     public var mediaEntry : MediaEntry?
     public var startTime : TimeInterval = 0
-    public var allowPlayerEngineExpose = false
-    public var subtitleLanguage: String?
-    public var audioLanguage: String?
-    public var plugins: [String : AnyObject]?
     
     // Builders
     @discardableResult
@@ -24,35 +20,25 @@ public class PlayerConfig: NSObject {
         return self
     }
        
-    @discardableResult
-    public func set(allowPlayerEngineExpose: Bool) -> Self {
-        self.allowPlayerEngineExpose = allowPlayerEngineExpose
-        return self
-    }
-    
     @discardableResult 
     public func set(startTime: TimeInterval) -> Self {
         self.startTime = startTime
         return self
     }
-    
-    @discardableResult 
-    public func set(subtitleLanguage: String) -> Self {
-        self.subtitleLanguage = subtitleLanguage
-        return self
-    } 
-    
-    @discardableResult 
-    public func set(audioLanguage: String) -> Self {
-        self.audioLanguage = audioLanguage
-        return self
-    }
-    
-    @discardableResult
-    public func set(plugins: [String : AnyObject]) -> Self {
-        self.plugins = plugins
-        return self
+}
+
+public class PluginConfig: NSObject {
+    public var config = [String : AnyObject]()
+    subscript(idx: String) -> AnyObject? {
+        get {
+            return self.config[idx]
+        }
+        set {
+            self.config[idx] = newValue
+        }
     }
 }
+
+
 
 

--- a/Classes/Player/PlayerController.swift
+++ b/Classes/Player/PlayerController.swift
@@ -12,6 +12,13 @@ import AVKit
 
 class PlayerController: NSObject, Player {
     
+    var onEventBlock: ((PKEvent)->Void)?
+    
+    var delegate: PlayerDelegate?
+    
+    private var currentPlayer: AVPlayerEngine?
+    private var assetBuilder: AssetBuilder?
+    
     public var duration: Double {
         get {
             guard let currentPlayer = self.currentPlayer else {
@@ -34,12 +41,6 @@ class PlayerController: NSObject, Player {
         }
     }
 
-    var onEventBlock: ((PKEvent)->Void)?
-    
-    var delegate: PlayerDelegate?
-    
-    private var currentPlayer: AVPlayerEngine?
-    private var assetBuilder: AssetBuilder?
     
     public var currentTime: TimeInterval {
         get {
@@ -76,7 +77,7 @@ class PlayerController: NSObject, Player {
         }
     }
     
-    public init(mediaEntry: PlayerConfig) {
+    public override init() {
         super.init()
         self.currentPlayer = AVPlayerEngine()
         self.currentPlayer?.onEventBlock = { [unowned self] (event:PKEvent) in

--- a/Classes/Player/PlayerController.swift
+++ b/Classes/Player/PlayerController.swift
@@ -80,18 +80,14 @@ class PlayerController: NSObject, Player {
     public override init() {
         super.init()
         self.currentPlayer = AVPlayerEngine()
-        self.currentPlayer?.onEventBlock = { [unowned self] (event:PKEvent) in
+        self.currentPlayer?.onEventBlock = { [unowned self] (event: PKEvent) in
             PKLog.trace("postEvent:: \(event)")
-            
-            if let block = self.onEventBlock {
-                block(event)
-            }
+            self.onEventBlock?(event)
         }
-        
         self.onEventBlock = nil
     }
     
-    func prepare(_ config: PlayerConfig) {
+    func prepare(_ config: MediaConfig) {
         if let player = self.currentPlayer {
             player.startPosition = config.startTime
             
@@ -130,7 +126,7 @@ class PlayerController: NSObject, Player {
         self.currentPlayer?.currentPosition = CMTimeGetSeconds(time)
     }
     
-    func prepareNext(_ config: PlayerConfig) -> Bool {
+    func prepareNext(_ config: MediaConfig) -> Bool {
         return false
     }
     

--- a/Classes/Player/PlayerController.swift
+++ b/Classes/Player/PlayerController.swift
@@ -80,9 +80,9 @@ class PlayerController: NSObject, Player {
     public override init() {
         super.init()
         self.currentPlayer = AVPlayerEngine()
-        self.currentPlayer?.onEventBlock = { [unowned self] (event: PKEvent) in
+        self.currentPlayer?.onEventBlock = { [weak self] event in
             PKLog.trace("postEvent:: \(event)")
-            self.onEventBlock?(event)
+            self?.onEventBlock?(event)
         }
         self.onEventBlock = nil
     }

--- a/Classes/Player/PlayerDecoratorBase.swift
+++ b/Classes/Player/PlayerDecoratorBase.swift
@@ -61,11 +61,11 @@ public class PlayerDecoratorBase: NSObject, Player {
         }
     }
     
-    public func prepare(_ config: PlayerConfig) {
+    public func prepare(_ config: MediaConfig) {
         return self.player.prepare(config)
     }
 
-    public func prepareNext(_ config: PlayerConfig) -> Bool {
+    public func prepareNext(_ config: MediaConfig) -> Bool {
         return self.player.prepareNext(config)
     }
     

--- a/Classes/Player/PlayerLoader.swift
+++ b/Classes/Player/PlayerLoader.swift
@@ -35,14 +35,13 @@ class PlayerLoader: PlayerDecoratorBase {
         
         var player: Player = playerController
         
-        if let plugins = pluginConfig {
-            for pluginName in plugins.config.keys {
-                if let pluginObject = PlayKitManager.sharedInstance.createPlugin(name: pluginName) {
+        if let pluginConfigs = pluginConfig?.config {
+            for pluginName in pluginConfigs.keys {
+                let pluginConfig = pluginConfigs[pluginName]
+                if let pluginObject = PlayKitManager.shared.createPlugin(name: pluginName, player: player, pluginConfig: pluginConfig, messageBus: self.messageBus) {
                     // TODO::
                     // send message bus
                     var decorator: PlayerDecoratorBase? = nil
-                    
-                    pluginObject.load(player: player, pluginConfig: plugins[pluginName], messageBus: self.messageBus)
                     
                     if let d = (pluginObject as? PlayerDecoratorProvider)?.getPlayerDecorator() {
                         d.setPlayer(player)
@@ -55,7 +54,14 @@ class PlayerLoader: PlayerDecoratorBase {
             }
         }
         setPlayer(player)
-        
+    }
+    
+    override func prepare(_ config: MediaConfig) {
+        // update all loaded plugins with media config
+        for (pluginName, loadedPlugin) in loadedPlugins {
+            loadedPlugin.plugin.onLoad(mediaConfig: config)
+        }
+        super.prepare(config)
     }
     
     func destroyPlayer() {
@@ -96,4 +102,5 @@ class PlayerLoader: PlayerDecoratorBase {
         // TODO:: finilizing + object validation
         messageBus.removeObserver(observer, events: events)
     }
+    
 }

--- a/Classes/Player/PlayerLoader.swift
+++ b/Classes/Player/PlayerLoader.swift
@@ -26,7 +26,7 @@ class PlayerLoader: PlayerDecoratorBase {
         var playerController: PlayerController
         
         playerController = PlayerController()
-        playerController.onEventBlock = { (event:PKEvent) in
+        playerController.onEventBlock = { [unowned self] event in
             self.messageBus.post(event)
         }
         

--- a/Classes/Plugins/Analytics/AnalyticsConfig.swift
+++ b/Classes/Plugins/Analytics/AnalyticsConfig.swift
@@ -9,10 +9,8 @@
 import UIKit
 
 public class AnalyticsConfig {
-    public var mediaEntry: MediaEntry?
-    public var params: [String: Any]!
     
-    public init() {
-        
-    }
+    public var params = [String : Any]()
+    
+    public init() {}
 }

--- a/Classes/Plugins/PKPlugin.swift
+++ b/Classes/Plugins/PKPlugin.swift
@@ -14,7 +14,7 @@ import AVFoundation
     /// The plugin name.
     static var pluginName: String { get }
     /// The associated media entry.
-    var mediaEntry: MediaEntry? { get set }
+    weak var mediaEntry: MediaEntry? { get set }
 
     init(player: Player, pluginConfig: Any?, messageBus: MessageBus)
     

--- a/Classes/Plugins/PKPlugin.swift
+++ b/Classes/Plugins/PKPlugin.swift
@@ -9,16 +9,19 @@
 import UIKit
 import AVFoundation
 
+/// The `PKPlugin` protocol defines all the properties and methods required to define a plugin object.
 @objc public protocol PKPlugin {
-    
+    /// The plugin name.
     static var pluginName: String { get }
-
+    /// The associated media entry.
     var mediaEntry: MediaEntry? { get set }
 
-    init()
-
+    init(player: Player, pluginConfig: Any?, messageBus: MessageBus)
     
-    func load(player: Player, pluginConfig: Any?, messageBus: MessageBus)
-    
+    /// On first load. used for doing initialization for the first time with the media config.
+    func onLoad(mediaConfig: MediaConfig)
+    /// On update media. used to update the plugin with new media config when available
+    func onUpdateMedia(mediaConfig: MediaConfig)
     func destroy()
 }
+

--- a/Classes/Plugins/PKPlugin.swift
+++ b/Classes/Plugins/PKPlugin.swift
@@ -13,9 +13,12 @@ import AVFoundation
     
     static var pluginName: String { get }
 
+    var mediaEntry: MediaEntry? { get set }
+
     init()
+
     
-    func load(player: Player, mediaConfig: MediaEntry, pluginConfig: Any?, messageBus: MessageBus)
+    func load(player: Player, pluginConfig: Any?, messageBus: MessageBus)
     
     func destroy()
 }

--- a/Plugins/IMA/IMAPlugin.swift
+++ b/Plugins/IMA/IMAPlugin.swift
@@ -11,10 +11,10 @@ import GoogleInteractiveMediaAds
 
 public class IMAPlugin: NSObject, AVPictureInPictureControllerDelegate, PlayerDecoratorProvider, AdsPlugin, IMAAdsLoaderDelegate, IMAAdsManagerDelegate, IMAWebOpenerDelegate, IMAContentPlayhead {
     
-    public var mediaEntry: MediaEntry?
+    public weak var mediaEntry: MediaEntry?
 
-    private var player: Player
-    private var messageBus: MessageBus
+    private unowned var player: Player
+    private unowned var messageBus: MessageBus
     
     weak var dataSource: AdsPluginDataSource? {
         didSet {

--- a/Plugins/IMA/IMAPlugin.swift
+++ b/Plugins/IMA/IMAPlugin.swift
@@ -10,6 +10,8 @@
 import GoogleInteractiveMediaAds
 
 public class IMAPlugin: NSObject, AVPictureInPictureControllerDelegate, PlayerDecoratorProvider, AdsPlugin, IMAAdsLoaderDelegate, IMAAdsManagerDelegate, IMAWebOpenerDelegate, IMAContentPlayhead {
+        
+    public var mediaEntry: MediaEntry?
 
     private var player: Player!
     
@@ -68,7 +70,7 @@ public class IMAPlugin: NSObject, AVPictureInPictureControllerDelegate, PlayerDe
         }
     }
     
-    public func load(player: Player, mediaConfig: MediaEntry, pluginConfig: Any?, messageBus: MessageBus) {
+    public func load(player: Player, pluginConfig: Any?, messageBus: MessageBus) {
         PKLog.trace("load")
         
         self.messageBus = messageBus
@@ -481,7 +483,9 @@ public class IMAPlugin: NSObject, AVPictureInPictureControllerDelegate, PlayerDe
     
 #else
     public class IMAPlugin:NSObject, PKPlugin  {
-        public func load(player: Player, mediaConfig: MediaEntry, pluginConfig: Any?, messageBus: MessageBus) {
+        public var mediaEntry: MediaEntry?
+
+        public func load(player: Player, pluginConfig: Any?, messageBus: MessageBus) {
             
         }
         

--- a/Plugins/IMA/IMAPlugin.swift
+++ b/Plugins/IMA/IMAPlugin.swift
@@ -10,12 +10,11 @@
 import GoogleInteractiveMediaAds
 
 public class IMAPlugin: NSObject, AVPictureInPictureControllerDelegate, PlayerDecoratorProvider, AdsPlugin, IMAAdsLoaderDelegate, IMAAdsManagerDelegate, IMAWebOpenerDelegate, IMAContentPlayhead {
-        
+    
     public var mediaEntry: MediaEntry?
 
-    private var player: Player!
-    
-    private var messageBus: MessageBus?
+    private var player: Player
+    private var messageBus: MessageBus
     
     weak var dataSource: AdsPluginDataSource? {
         didSet {
@@ -36,7 +35,7 @@ public class IMAPlugin: NSObject, AVPictureInPictureControllerDelegate, PlayerDe
     private var pictureInPictureProxy: IMAPictureInPictureProxy?
     private var loadingView: UIView?
     
-    private var config: AdsConfig!
+    private var config: AdsConfig?
     private var adTagUrl: String?
     private var tagsTimes: [TimeInterval : String]? {
         didSet {
@@ -58,73 +57,72 @@ public class IMAPlugin: NSObject, AVPictureInPictureControllerDelegate, PlayerDe
         }
     }
     
-    override public required init() {
-        
-    }
+    /************************************************************/
+    // MARK: - PKPlugin
+    /************************************************************/
     
-    //MARK: plugin protocol methods
-    
-    public static var pluginName: String {
-        get {
-            return String(describing: IMAPlugin.self)
-        }
-    }
-    
-    public func load(player: Player, pluginConfig: Any?, messageBus: MessageBus) {
-        PKLog.trace("load")
-        
+    public required init(player: Player, pluginConfig: Any?, messageBus: MessageBus) {
         self.messageBus = messageBus
-        
+        self.player = player
+        super.init()
         if let adsConfig = pluginConfig as? AdsConfig {
             self.config = adsConfig
-            self.player = player
-            
             if IMAPlugin.loader == nil {
-                self.setupLoader(with: self.config)
+                self.setupLoader(with: adsConfig)
             }
             
             IMAPlugin.loader.contentComplete()
             IMAPlugin.loader.delegate = self
             
-            if let adTagUrl = self.config.adTagUrl {
+            if let adTagUrl = adsConfig.adTagUrl {
                 self.adTagUrl = adTagUrl
-            } else if let adTagsTimes = self.config.tagsTimes {
+            } else if let adTagsTimes = adsConfig.tagsTimes {
                 self.tagsTimes = adTagsTimes
+                self.sortedTagsTimes = adTagsTimes.keys.sorted()
             }
         }
-
+        
         var events: [PKEvent.Type] = []
         events.append(PlayerEvent.ended)
-        self.messageBus?.addObserver(self, events: events, block: { (data: Any) -> Void in
+        self.messageBus.addObserver(self, events: events, block: { (data: Any) -> Void in
             self.contentComplete()
         })
-
+        
         self.timer = Timer.scheduledTimer(timeInterval: 0.2, target: self, selector: #selector(IMAPlugin.update), userInfo: nil, repeats: true)
     }
-
+    
+    public func onLoad(mediaConfig: MediaConfig) {
+        PKLog.trace("plugin \(type(of:self)) onLoad with media config: \(mediaConfig)")
+        self.mediaEntry = mediaConfig.mediaEntry
+    }
+    
+    public func onUpdateMedia(mediaConfig: MediaConfig) {
+        PKLog.trace("plugin \(type(of:self)) onUpdateMedia with media config: \(mediaConfig)")
+        self.mediaEntry = mediaConfig.mediaEntry
+    }
+    
+    public static var pluginName = String(describing: IMAPlugin.self)
+    
     public func destroy() {
         PKLog.trace("destroy")
         self.destroyManager()
-        self.player = nil
         self.timer?.invalidate()
     }
+    
+    /************************************************************/
+    // MARK: - Internal
+    /************************************************************/
     
     func getPlayerDecorator() -> PlayerDecoratorBase? {
         return AdsEnabledPlayerController(adsPlugin: self)
     }
-    //MARK: public methods
     
     func requestAds() {
         if self.adTagUrl != nil && self.adTagUrl != "" {
             self.startAdCalled = false
             
             var request: IMAAdsRequest
-            
-//            if let avPlayer = self.player.playerEngine as? AVPlayer {
-//                request = IMAAdsRequest(adTagUrl: self.adTagUrl, adDisplayContainer: self.createAdDisplayContainer(), avPlayerVideoDisplay: IMAAVPlayerVideoDisplay(avPlayer: avPlayer), pictureInPictureProxy: self.pictureInPictureProxy, userContext: nil)
-//            } else {
-                request = IMAAdsRequest(adTagUrl: self.adTagUrl, adDisplayContainer: self.createAdDisplayContainer(), contentPlayhead: self, userContext: nil)
-//            }
+            request = IMAAdsRequest(adTagUrl: self.adTagUrl, adDisplayContainer: self.createAdDisplayContainer(), contentPlayhead: self, userContext: nil)
             
             IMAPlugin.loader.requestAds(with: request)
             PKLog.trace("request Ads")
@@ -164,7 +162,9 @@ public class IMAPlugin: NSObject, AVPictureInPictureControllerDelegate, PlayerDe
         IMAPlugin.loader.contentComplete()
     }
     
-    //MARK: private methods
+    /************************************************************/
+    // MARK: - Private
+    /************************************************************/
     
     private func setupLoader(with config: AdsConfig) {
         let imaSettings: IMASettings! = IMASettings()
@@ -180,8 +180,8 @@ public class IMAPlugin: NSObject, AVPictureInPictureControllerDelegate, PlayerDe
 //            self.pictureInPictureProxy = IMAPictureInPictureProxy(avPictureInPictureControllerDelegate: self)
 //        }
         
-        if (self.config.companionView != nil) {
-            self.companionSlot = IMACompanionAdSlot(view: self.config.companionView, width: Int32(self.config.companionView!.frame.size.width), height: Int32(self.config.companionView!.frame.size.height))
+        if let companionView = self.config?.companionView {
+            self.companionSlot = IMACompanionAdSlot(view: companionView, width: Int32(companionView.frame.size.width), height: Int32(companionView.frame.size.height))
         }
     }
     
@@ -209,7 +209,7 @@ public class IMAPlugin: NSObject, AVPictureInPictureControllerDelegate, PlayerDe
     }
     
     private func createAdDisplayContainer() -> IMAAdDisplayContainer {
-        return IMAAdDisplayContainer(adContainer: self.player.view, companionSlots: self.config.companionView != nil ? [self.companionSlot!] : nil)
+        return IMAAdDisplayContainer(adContainer: self.player.view, companionSlots: self.config?.companionView != nil ? [self.companionSlot!] : nil)
     }
 
     private func loadAdsIfNeeded() {
@@ -260,14 +260,13 @@ public class IMAPlugin: NSObject, AVPictureInPictureControllerDelegate, PlayerDe
     
     private func createRenderingSettings() {
         self.renderingSettings.webOpenerDelegate = self
-        if let webOpenerPresentingController = self.config.webOpenerPresentingController {
+        if let webOpenerPresentingController = self.config?.webOpenerPresentingController {
             self.renderingSettings.webOpenerPresentingController = webOpenerPresentingController
         }
-        
-        if let bitrate = self.config.videoBitrate {
+        if let bitrate = self.config?.videoBitrate {
             self.renderingSettings.bitrate = bitrate
         }
-        if let mimeTypes = self.config.videoMimeTypes {
+        if let mimeTypes = self.config?.videoMimeTypes {
             self.renderingSettings.mimeTypes = mimeTypes
         }
     }
@@ -326,7 +325,7 @@ public class IMAPlugin: NSObject, AVPictureInPictureControllerDelegate, PlayerDe
 
     private func notify(event: AdEvent) {
         self.delegate?.adsPlugin(self, didReceive: event)
-        self.messageBus?.post(event)
+        self.messageBus.post(event)
     }
     
     private func destroyManager() {
@@ -337,19 +336,17 @@ public class IMAPlugin: NSObject, AVPictureInPictureControllerDelegate, PlayerDe
     // MARK: AdsLoaderDelegate
     
     public func adsLoader(_ loader: IMAAdsLoader!, adsLoadedWith adsLoadedData: IMAAdsLoadedData!) {
-        if let _ = self.player {
-            self.loaderFailed = false
-            
-            self.manager = adsLoadedData.adsManager
-            self.manager!.delegate = self
-            self.createRenderingSettings()
-            
-            if self.startAdCalled {
-                self.manager!.initialize(with: self.renderingSettings)
-            }
-            
-            PKLog.trace("ads manager set")
+        self.loaderFailed = false
+        
+        self.manager = adsLoadedData.adsManager
+        self.manager!.delegate = self
+        self.createRenderingSettings()
+        
+        if self.startAdCalled {
+            self.manager!.initialize(with: self.renderingSettings)
         }
+        
+        PKLog.trace("ads manager set")
     }
     
     public func adsLoader(_ loader: IMAAdsLoader!, failedWith adErrorData: IMAAdLoadingErrorData!) {
@@ -482,22 +479,25 @@ public class IMAPlugin: NSObject, AVPictureInPictureControllerDelegate, PlayerDe
 }
     
 #else
-    public class IMAPlugin:NSObject, PKPlugin  {
-        public var mediaEntry: MediaEntry?
-
-        public func load(player: Player, pluginConfig: Any?, messageBus: MessageBus) {
+    public class IMAPlugin: NSObject, PKPlugin  {
+        
+        public required init(player: Player, pluginConfig: Any?, messageBus: MessageBus) {
             
         }
-        
-        public static var pluginName: String {
-            get {
-                return String(describing: IMAPlugin.self)
-            }
+
+        public func onLoad(mediaConfig: MediaConfig) {
+            PKLog.trace("plugin \(type(of:self)) onLoad with media config: \(mediaConfig)")
+            self.mediaEntry = mediaConfig.mediaEntry
         }
         
-        override public required init() {
-            super.init()
+        public func onUpdateMedia(mediaConfig: MediaConfig) {
+            PKLog.trace("plugin \(type(of:self)) onUpdateMedia with media config: \(mediaConfig)")
+            self.mediaEntry = mediaConfig.mediaEntry
         }
+        
+        public var mediaEntry: MediaEntry?
+        
+        public static var pluginName = String(describing: IMAPlugin.self)
         
         public func destroy() {
             

--- a/Plugins/KalturaStats/KalturaStatsPlugin.swift
+++ b/Plugins/KalturaStats/KalturaStatsPlugin.swift
@@ -52,12 +52,12 @@ public class KalturaStatsPlugin: PKPlugin {
         case ERROR = 99
     }
     
-    private var player: Player
-    private var messageBus: MessageBus
+    private unowned var player: Player
+    private unowned var messageBus: MessageBus
     private var config: AnalyticsConfig?
     
     public static var pluginName: String = "KalturaStatsPlugin"
-    public var mediaEntry: MediaEntry?
+    public weak var mediaEntry: MediaEntry?
     
     private var isFirstPlay = true
     private var isWidgetLoaded = false

--- a/Plugins/Phoenix/KalturaPluginManager.swift
+++ b/Plugins/Phoenix/KalturaPluginManager.swift
@@ -29,8 +29,8 @@ final class KalturaPluginManager {
 
     public var delegate: KalturaPluginManagerDelegate?
     
-    private var player: Player?
-    private var messageBus: MessageBus?
+    private var player: Player
+    private var messageBus: MessageBus
     private var config: AnalyticsConfig?
     
     private var isFirstPlay = true
@@ -39,15 +39,17 @@ final class KalturaPluginManager {
     private var timer: Timer?
     private var interval = 30 //Should be provided in plugin config
     
-    public func load(player: Player, pluginConfig: Any?, messageBus: MessageBus) {
+    init(player: Player, pluginConfig: Any?, messageBus: MessageBus) {
+        self.player = player
         self.messageBus = messageBus
-        
+        self.load(pluginConfig: pluginConfig)
+    }
+    
+    func load(pluginConfig: Any?) {
         if let aConfig = pluginConfig as? AnalyticsConfig {
             self.config = aConfig
-            self.player = player
         }
-        
-        registerToAllEvents()
+        self.registerToAllEvents()
         AppStateSubject.sharedInstance.add(observer: self)
     }
     
@@ -59,33 +61,29 @@ final class KalturaPluginManager {
     
     func registerToAllEvents() {
         PKLog.trace("Register to all events")
-        guard let messageBus = self.messageBus else {
-            PKLog.error("message bus is nil! shouldn't happen")
-            return
-        }
 
-        messageBus.addObserver(self, events: [PlayerEvent.ended], block: { (info) in
+        self.messageBus.addObserver(self, events: [PlayerEvent.ended], block: { (info) in
             PKLog.trace("ended info: \(info)")
             self.stopTimer()
             self.delegate?.pluginManagerDidSendAnalyticsEvent(action: .finish)
         })
         
-        messageBus.addObserver(self, events: [PlayerEvent.error], block: { (info) in
+        self.messageBus.addObserver(self, events: [PlayerEvent.error], block: { (info) in
             PKLog.trace("error info: \(info)")
             self.delegate?.pluginManagerDidSendAnalyticsEvent(action: .error)
         })
         
-        messageBus.addObserver(self, events: [PlayerEvent.pause], block: { (info) in
+        self.messageBus.addObserver(self, events: [PlayerEvent.pause], block: { (info) in
             PKLog.trace("pause info: \(info)")
             self.delegate?.pluginManagerDidSendAnalyticsEvent(action: .pause)
         })
         
-        messageBus.addObserver(self, events: [PlayerEvent.loadedMetadata], block: { (info) in
+        self.messageBus.addObserver(self, events: [PlayerEvent.loadedMetadata], block: { (info) in
             PKLog.trace("loadedMetadata info: \(info)")
             self.delegate?.pluginManagerDidSendAnalyticsEvent(action: .load)
         })
         
-        messageBus.addObserver(self, events: [PlayerEvent.playing], block: { (info) in
+        self.messageBus.addObserver(self, events: [PlayerEvent.playing], block: { (info) in
             PKLog.trace("play info: \(info)")
             
             if !self.intervalOn {
@@ -103,7 +101,7 @@ final class KalturaPluginManager {
     }
     
     public func reportConcurrencyEvent() {
-        self.messageBus?.post(OttEvent.OttEventConcurrency())
+        self.messageBus.post(OttEvent.OttEventConcurrency())
     }
     
     /************************************************************/
@@ -130,13 +128,11 @@ final class KalturaPluginManager {
         
         self.delegate?.pluginManagerDidSendAnalyticsEvent(action: .hit);
         
-        if let player = self.player {
-            var progress = Float(player.currentTime) / Float(player.duration)
-            PKLog.trace("Progress is \(progress)")
-            
-            if progress > 0.98 {
-                self.delegate?.pluginManagerDidSendAnalyticsEvent(action: .finish)
-            }
+        var progress = Float(player.currentTime) / Float(player.duration)
+        PKLog.trace("Progress is \(progress)")
+        
+        if progress > 0.98 {
+            self.delegate?.pluginManagerDidSendAnalyticsEvent(action: .finish)
         }
     }
     

--- a/Plugins/Phoenix/KalturaPluginManager.swift
+++ b/Plugins/Phoenix/KalturaPluginManager.swift
@@ -29,8 +29,8 @@ final class KalturaPluginManager {
 
     public var delegate: KalturaPluginManagerDelegate?
     
-    private var player: Player
-    private var messageBus: MessageBus
+    private unowned var player: Player
+    private unowned var messageBus: MessageBus
     private var config: AnalyticsConfig?
     
     private var isFirstPlay = true

--- a/Plugins/Phoenix/PhoenixAnalyticsPlugin.swift
+++ b/Plugins/Phoenix/PhoenixAnalyticsPlugin.swift
@@ -10,7 +10,7 @@ import UIKit
 
 public class PhoenixAnalyticsPlugin: PKPlugin, KalturaPluginManagerDelegate {
 
-    private var player: Player!
+    private unowned var player: Player
     private var config: AnalyticsConfig!
     private var kalturaPluginManager: KalturaPluginManager!
     

--- a/Plugins/Phoenix/PhoenixAnalyticsPlugin.swift
+++ b/Plugins/Phoenix/PhoenixAnalyticsPlugin.swift
@@ -15,7 +15,7 @@ public class PhoenixAnalyticsPlugin: PKPlugin, KalturaPluginManagerDelegate {
     private var kalturaPluginManager: KalturaPluginManager!
     
     public static var pluginName: String = "PhoenixAnalytics"
-    public var mediaEntry: MediaEntry?
+    public weak var mediaEntry: MediaEntry?
     
     /************************************************************/
     // MARK: - PKPlugin

--- a/Plugins/Phoenix/PhoenixAnalyticsPlugin.swift
+++ b/Plugins/Phoenix/PhoenixAnalyticsPlugin.swift
@@ -10,37 +10,45 @@ import UIKit
 
 public class PhoenixAnalyticsPlugin: PKPlugin, KalturaPluginManagerDelegate {
 
-    public static var pluginName: String = "PhoenixAnalytics"
-
     private var player: Player!
     private var config: AnalyticsConfig!
-    private var mediaEntry: MediaEntry!
-
     private var kalturaPluginManager: KalturaPluginManager!
     
-    required public init() {
-        
-    }
+    public static var pluginName: String = "PhoenixAnalytics"
+    public var mediaEntry: MediaEntry?
     
-    public func load(player: Player, mediaConfig: MediaEntry, pluginConfig: Any?, messageBus: MessageBus) {
-        self.kalturaPluginManager = KalturaPluginManager()
-        
-        self.mediaEntry = mediaConfig
+    /************************************************************/
+    // MARK: - PKPlugin
+    /************************************************************/
+    
+    public required init(player: Player, pluginConfig: Any?, messageBus: MessageBus) {
+        self.player = player
         if let aConfig = pluginConfig as? AnalyticsConfig {
-            self.player = player
             self.config = aConfig
         }
-
+        self.kalturaPluginManager = KalturaPluginManager(player: player, pluginConfig: pluginConfig, messageBus: messageBus)
         self.kalturaPluginManager.delegate = self
-        self.kalturaPluginManager.load(player: player, pluginConfig: pluginConfig, messageBus: messageBus)
-
+    }
+    
+    public func onLoad(mediaConfig: MediaConfig) {
+        PKLog.trace("plugin \(type(of:self)) onLoad with media config: \(mediaConfig)")
+        self.mediaEntry = mediaConfig.mediaEntry
+    }
+    
+    public func onUpdateMedia(mediaConfig: MediaConfig) {
+        PKLog.trace("plugin \(type(of:self)) onUpdateMedia with media config: \(mediaConfig)")
+        self.mediaEntry = mediaConfig.mediaEntry
     }
     
     public func destroy() {
         self.kalturaPluginManager.destroy()
     }
     
-    internal func pluginManagerDidSendAnalyticsEvent(action: PhoenixAnalyticsType) {
+    /************************************************************/
+    // MARK: - KalturaPluginManagerDelegate
+    /************************************************************/
+    
+    func pluginManagerDidSendAnalyticsEvent(action: PhoenixAnalyticsType) {
         PKLog.trace("Action: \(action)")
         
         var fileId = ""
@@ -64,15 +72,19 @@ public class PhoenixAnalyticsPlugin: PKPlugin, KalturaPluginManagerDelegate {
             parterId = pId
         }
 
+        guard let mediaEntry = self.mediaEntry else {
+            PKLog.error("send analytics failed due to nil mediaEntry")
+            return
+        }
+        
         if let builder: KalturaRequestBuilder = BookmarkService.actionAdd(baseURL: baseUrl,
                                                                        partnerId: parterId,
                                                                        ks: ks,
                                                                        eventType: action.rawValue.uppercased(),
                                                                        currentTime: self.player.currentTime.toInt32(),
-                                                                       assetId: self.mediaEntry.id,
+                                                                       assetId: mediaEntry.id,
                                                                        fileId: fileId) {
             builder.set { (response: Response) in
-                
                 PKLog.trace("Response: \(response)")
                 if response.statusCode == 0 {
                     PKLog.trace("\(response.data)")
@@ -87,14 +99,10 @@ public class PhoenixAnalyticsPlugin: PKPlugin, KalturaPluginManagerDelegate {
                         }
                     }
                 }
-                
             }
-            
             USRExecutor.shared.send(request: builder.build())
         }
-        
     }
-    
 }
 
 

--- a/Plugins/Phoenix/TVPAPIAnalyticsPlugin.swift
+++ b/Plugins/Phoenix/TVPAPIAnalyticsPlugin.swift
@@ -10,36 +10,44 @@ import UIKit
 import SwiftyJSON
 
 public class TVPAPIAnalyticsPlugin: PKPlugin, KalturaPluginManagerDelegate {
-
+    
     public static var pluginName: String = "TVPAPIAnalytics"
+    public var mediaEntry: MediaEntry?
     
-    private var player: Player!
-    private var config: AnalyticsConfig!
-    private var mediaEntry: MediaEntry!
+    private var player: Player
+    private var config: AnalyticsConfig?
+    private var kalturaPluginManager: KalturaPluginManager
     
-    private var kalturaPluginManager: KalturaPluginManager!
+    /************************************************************/
+    // MARK: - PKPlugin
+    /************************************************************/
     
-    required public init() {
-        
-    }
-    
-    public func load(player: Player, mediaConfig: MediaEntry, pluginConfig: Any?, messageBus: MessageBus) {
-        self.kalturaPluginManager = KalturaPluginManager()
-        
-        self.mediaEntry = mediaConfig
+    public required init(player: Player, pluginConfig: Any?, messageBus: MessageBus) {
+        self.player = player
         if let aConfig = pluginConfig as? AnalyticsConfig {
-            self.player = player
             self.config = aConfig
         }
-        
+        self.kalturaPluginManager = KalturaPluginManager(player: player, pluginConfig: pluginConfig, messageBus: messageBus)
         self.kalturaPluginManager.delegate = self
-        self.kalturaPluginManager.load(player: player, pluginConfig: pluginConfig, messageBus: messageBus)
-        
+    }
+    
+    public func onLoad(mediaConfig: MediaConfig) {
+        PKLog.trace("plugin \(type(of:self)) onLoad with media config: \(mediaConfig)")
+        self.mediaEntry = mediaConfig.mediaEntry
+    }
+    
+    public func onUpdateMedia(mediaConfig: MediaConfig) {
+        PKLog.trace("plugin \(type(of:self)) onUpdateMedia with media config: \(mediaConfig)")
+        self.mediaEntry = mediaConfig.mediaEntry
     }
     
     public func destroy() {
         self.kalturaPluginManager.destroy()
     }
+    
+    /************************************************************/
+    // MARK: - KalturaPluginManagerDelegate
+    /************************************************************/
     
     internal func pluginManagerDidSendAnalyticsEvent(action: PhoenixAnalyticsType) {
         PKLog.trace("Action: \(action)")
@@ -50,25 +58,28 @@ public class TVPAPIAnalyticsPlugin: PKPlugin, KalturaPluginManagerDelegate {
         
         let method = action == .hit ? "MediaHit" : "MediaMark"
 
-        if let url = self.config.params["baseUrl"] as? String {
+        if let url = self.config?.params["baseUrl"] as? String {
             baseUrl = url
         }
-        
-        if let fId = self.config.params["fileId"] as? String {
+        if let fId = self.config?.params["fileId"] as? String {
             fileId = fId
         }
-
-        if let obj = self.config.params["initObj"] as? JSON {
+        if let obj = self.config?.params["initObj"] as? JSON {
             initObj = obj
         }
         
         baseUrl = "\(baseUrl)m=\(method)"
         
+        guard let mediaEntry = self.mediaEntry else {
+            PKLog.error("send analytics failed due to nil mediaEntry")
+            return
+        }
+        
         if let builder: RequestBuilder = MediaMarkService.sendTVPAPIEVent(baseURL: baseUrl,
                                                                                  initObj: initObj,
                                                                                  eventType: action.rawValue,
                                                                                  currentTime: self.player.currentTime.toInt32(),
-                                                                                 assetId: self.mediaEntry.id,
+                                                                                 assetId: mediaEntry.id,
                                                                                  fileId: fileId) {
             builder.set { (response: Response) in
                 

--- a/Plugins/Phoenix/TVPAPIAnalyticsPlugin.swift
+++ b/Plugins/Phoenix/TVPAPIAnalyticsPlugin.swift
@@ -14,7 +14,7 @@ public class TVPAPIAnalyticsPlugin: PKPlugin, KalturaPluginManagerDelegate {
     public static var pluginName: String = "TVPAPIAnalytics"
     public weak var mediaEntry: MediaEntry?
     
-    private var player: Player
+    private unowned var player: Player
     private var config: AnalyticsConfig?
     private var kalturaPluginManager: KalturaPluginManager
     

--- a/Plugins/Phoenix/TVPAPIAnalyticsPlugin.swift
+++ b/Plugins/Phoenix/TVPAPIAnalyticsPlugin.swift
@@ -12,7 +12,7 @@ import SwiftyJSON
 public class TVPAPIAnalyticsPlugin: PKPlugin, KalturaPluginManagerDelegate {
     
     public static var pluginName: String = "TVPAPIAnalytics"
-    public var mediaEntry: MediaEntry?
+    public weak var mediaEntry: MediaEntry?
     
     private var player: Player
     private var config: AnalyticsConfig?

--- a/Plugins/Youbora/YouboraManager.swift
+++ b/Plugins/Youbora/YouboraManager.swift
@@ -16,39 +16,42 @@ import AVKit
 class YouboraManager: YBPluginGeneric {
 
     private var pkPlayer: Player!
-    private var mediaEntry: MediaEntry!
+    var mediaEntry: MediaEntry!
     public var currentBitrate: Double?
     
-    init!(options: NSObject!, player: Player, media: MediaEntry) {
+    init!(options: NSObject!, player: Player, mediaEntry: MediaEntry) {
         super.init(options: options)
         self.pkPlayer = player
-        self.mediaEntry = media
+        self.mediaEntry = mediaEntry
     }
     
-    override init() {
+    private override init() {
         super.init()
     }
     
-    //MARK: Override methods
-    override func getMediaDuration() -> NSNumber! {
-        return pkPlayer.duration as NSNumber!
+    /************************************************************/
+    // MARK: - Overrides
+    /************************************************************/
+    
+    override func getMediaDuration() -> NSNumber {
+        return NSNumber(value: pkPlayer.duration)
     }
     
-    override func getResource() -> String! {
+    override func getResource() -> String {
         PKLog.trace("Resource")
         return self.mediaEntry.id
     }
     
-    override func getPlayhead() -> NSNumber! {
+    override func getPlayhead() -> NSNumber {
         let currentTIme = self.pkPlayer.currentTime
-        return currentTIme as NSNumber!
+        return NSNumber(value: currentTIme)
     }
     
-    override func getPlayerVersion() -> String! {
-        return "PlayKit-0.1.0"
+    override func getPlayerVersion() -> String {
+        return "PlayKit-\(PlayKitManager.versionString)"
     }
     
-    override func getBitrate() -> NSNumber! {
+    override func getBitrate() -> NSNumber {
         if let bitrate = currentBitrate {
             return NSNumber(value: bitrate)
         }

--- a/Plugins/Youbora/YouboraManager.swift
+++ b/Plugins/Youbora/YouboraManager.swift
@@ -15,10 +15,13 @@ import AVKit
 
 class YouboraManager: YBPluginGeneric {
 
-    private var pkPlayer: Player!
-    var mediaEntry: MediaEntry!
+    private weak var pkPlayer: Player?
+    weak var mediaEntry: MediaEntry?
     public var currentBitrate: Double?
     
+    // for some reason we must implement the initializer this way because the way youbora implemented the init.
+    // this means player and media entry are defined as optionals but they must have values when initialized.
+    // All the checks for optionals in this class are just because we defined them as optionals but they are not so the checks are irrelevant.
     init!(options: NSObject!, player: Player, mediaEntry: MediaEntry) {
         super.init(options: options)
         self.pkPlayer = player
@@ -34,16 +37,16 @@ class YouboraManager: YBPluginGeneric {
     /************************************************************/
     
     override func getMediaDuration() -> NSNumber {
-        return NSNumber(value: pkPlayer.duration)
+        return NSNumber(value: pkPlayer?.duration ?? 0)
     }
     
     override func getResource() -> String {
         PKLog.trace("Resource")
-        return self.mediaEntry.id
+        return self.mediaEntry?.id ?? ""
     }
     
     override func getPlayhead() -> NSNumber {
-        let currentTIme = self.pkPlayer.currentTime
+        let currentTIme = self.pkPlayer?.currentTime ?? 0
         return NSNumber(value: currentTIme)
     }
     

--- a/Plugins/Youbora/YouboraPlugin.swift
+++ b/Plugins/Youbora/YouboraPlugin.swift
@@ -3,7 +3,7 @@
 //  AdvancedExample
 //
 //  Created by Oded Klein on 19/10/2016.
-//  Copyright © 2016 Google, Inc. All rights reserved.
+//  Copyright © 2016 Kaltura, Inc. All rights reserved.
 //
 
 import YouboraLib
@@ -12,171 +12,166 @@ import AVFoundation
 
 public class YouboraPlugin: PKPlugin {
 
-    private var player: Player!
-    private var messageBus: MessageBus?
-    private var config: AnalyticsConfig!
-    private var mediaEntry: MediaEntry!
-    
-    private var youboraManager : YouboraManager!
-    public static var pluginName: String = "YouboraPlugin"
-
+    private var player: Player
+    private var messageBus: MessageBus
+    private var config: AnalyticsConfig?
+    private var youboraManager : YouboraManager?
     private var isFirstPlay = true
     
-    required public init() {
-
-    }
+    public static var pluginName: String = "YouboraPlugin"
+    public var mediaEntry: MediaEntry?
     
-    public func load(player: Player, pluginConfig: Any?, messageBus: MessageBus) {
+    /************************************************************/
+    // MARK: - PKPlugin
+    /************************************************************/
     
+    public required init(player: Player, pluginConfig: Any?, messageBus: MessageBus) {
+        self.player = player
         self.messageBus = messageBus
-//        self.mediaEntry = mediaConfig
-        
         if let aConfig = pluginConfig as? AnalyticsConfig {
             self.config = aConfig
-            self.player = player
         } else {
             PKLog.warning("There is no Analytics Config.")
         }
-        
-        setupOptions()
-        
-        registerToAllEvents()
-        
-        startMonitoring(player: player)
+    }
+    
+    public func onLoad(mediaConfig: MediaConfig) {
+        PKLog.trace("plugin \(type(of:self)) onLoad with media config: \(mediaConfig)")
+        self.mediaEntry = mediaConfig.mediaEntry
+        self.setupYouboraManager() { succeeded in
+            if succeeded {
+                self.registerToAllEvents()
+                self.startMonitoring(player: self.player)
+            }
+        }
+    }
+    
+    public func onUpdateMedia(mediaConfig: MediaConfig) {
+        PKLog.trace("plugin \(type(of:self)) onLoad with media config: \(mediaConfig)")
+        self.mediaEntry = mediaConfig.mediaEntry
+        self.setupYouboraManager()
     }
     
     public func destroy() {
-        stopMonitoring()
+        self.stopMonitoring()
     }
     
-    private func setupOptions() {
-        let options = self.config.params
-        if var media = options?["media"] as? [String: Any] {
-            if let entry = self.mediaEntry {
-                media["resource"] = entry.id
-                media["title"] = entry.id
-                media["duration"] = self.player.duration
-                
-            } else {
-                PKLog.warning("There is no MediaEntry")
-            }
+    /************************************************************/
+    // MARK: - Private
+    /************************************************************/
+    
+    private func setupYouboraManager(completionHandler: ((_ succeeded: Bool) -> Void)? = nil) {
+        if let config = self.config, var media = config.params["media"] as? [String : Any], let mediaEntry = self.mediaEntry {
+            media["resource"] = mediaEntry.id
+            media["title"] = mediaEntry.id
+            media["duration"] = self.player.duration
+            config.params["media"] = media
+            youboraManager = YouboraManager(options: config.params as NSObject!, player: player, mediaEntry: mediaEntry)
+            completionHandler?(true)
+        } else {
+            PKLog.warning("There is no config params or MediaEntry, could not setup youbora manager")
+            completionHandler?(false)
         }
-        youboraManager = YouboraManager(options: options as NSObject!, player: player, media: self.mediaEntry)
-	
     }
     
     private func startMonitoring(player: Player) {
+        guard let youboraManager = self.youboraManager else { return }
         PKLog.trace("Start monitoring using Youbora")
         youboraManager.startMonitoring(withPlayer: youboraManager)
     }
     
     private func stopMonitoring() {
+        guard let youboraManager = self.youboraManager else { return }
         PKLog.trace("Stop monitoring using Youbora")
         youboraManager.stopMonitoring()
     }
     
     private func registerToAllEvents() {
+        PKLog.trace("register to all events")
         
-        PKLog.trace()
+        self.messageBus.addObserver(self, events: [PlayerEvent.canPlay], block: { [unowned self] event in
+            self.postEventLogWithMessage(message: "canPlay event: \(event)")
+        })
         
-        self.messageBus?.addObserver(self, events: [PlayerEvent.canPlay], block: { (info) in
-            PKLog.trace("canPlay info: \(info)")
+        self.messageBus.addObserver(self, events: [PlayerEvent.play], block: { [unowned self] event in
+            guard let youboraManager = self.youboraManager else { return }
+            youboraManager.playHandler()
+            self.postEventLogWithMessage(message: "play event: \(event)")
+        })
+        
+        self.messageBus.addObserver(self, events: [PlayerEvent.playing], block: { [unowned self] event in
+            self.postEventLogWithMessage(message: "playing event: \(event)")
             
-            self.postEventLogWithMessage(message: "Event info: \(info)")
-        })
-        
-        self.messageBus?.addObserver(self, events: [PlayerEvent.play], block: { (info) in
-            PKLog.trace("play info: \(info)")
-            self.youboraManager.playHandler()
-            self.postEventLogWithMessage(message: "Event info: \(info)")
-        })
-        
-        self.messageBus?.addObserver(self, events: [PlayerEvent.playing], block: { (info) in
-            PKLog.trace("playing info: \(info)")
-            self.postEventLogWithMessage(message: "Event info: \(info)")
-
+            guard let youboraManager = self.youboraManager else { return }
             if self.isFirstPlay {
-                self.youboraManager.joinHandler()
-                self.youboraManager.bufferedHandler()
+                youboraManager.joinHandler()
+                youboraManager.bufferedHandler()
                 self.isFirstPlay = false
             } else {
-                self.youboraManager.resumeHandler()
+                youboraManager.resumeHandler()
             }
         })
         
-        self.messageBus?.addObserver(self, events: [PlayerEvent.pause], block: { (info) in
-            PKLog.trace("pause info: \(info)")
-            self.youboraManager.pauseHandler()
-            self.postEventLogWithMessage(message: "Event info: \(info)")
+        self.messageBus.addObserver(self, events: [PlayerEvent.pause], block: { [unowned self] event in
+            guard let youboraManager = self.youboraManager else { return }
+            youboraManager.pauseHandler()
+            self.postEventLogWithMessage(message: "pause event: \(event)")
         })
         
-        self.messageBus?.addObserver(self, events: [PlayerEvent.seeking], block: { (info) in
-            PKLog.trace("seeking info: \(info)")
-            self.youboraManager.seekingHandler()
-            
-            self.postEventLogWithMessage(message: "Event info: \(info)")
+        self.messageBus.addObserver(self, events: [PlayerEvent.seeking], block: { [unowned self] event in
+            guard let youboraManager = self.youboraManager else { return }
+            youboraManager.seekingHandler()
+            self.postEventLogWithMessage(message: "seeking event: \(event)")
         })
         
-        self.messageBus?.addObserver(self, events: [PlayerEvent.seeked], block: { (info) in
-            PKLog.trace("seeked info: \(info)")
-            self.youboraManager.seekedHandler()
-            
-            self.postEventLogWithMessage(message: "Event info: \(info)")
+        self.messageBus.addObserver(self, events: [PlayerEvent.seeked], block: { [unowned self] (event) in
+            guard let youboraManager = self.youboraManager else { return }
+            youboraManager.seekedHandler()
+            self.postEventLogWithMessage(message: "seeked event: \(event)")
         })
         
-        self.messageBus?.addObserver(self, events: [PlayerEvent.ended], block: { (info) in
-            PKLog.trace("ended info: \(info)")
-            self.youboraManager.endedHandler()
-            
-            self.postEventLogWithMessage(message: "Event info: \(info)")
+        self.messageBus.addObserver(self, events: [PlayerEvent.ended], block: { [unowned self] (event) in
+            guard let youboraManager = self.youboraManager else { return }
+            youboraManager.endedHandler()
+            self.postEventLogWithMessage(message: "ended event: \(event)")
         })
         
-        self.messageBus?.addObserver(self, events: [PlayerEvent.playbackParamsUpdated], block: { (info) in
-            PKLog.trace("playbackParamsUpdated info: \(info)")
-            self.youboraManager.currentBitrate = info.currentBitrate?.doubleValue
-            self.postEventLogWithMessage(message: "Event info: \(info)")
+        self.messageBus.addObserver(self, events: [PlayerEvent.playbackParamsUpdated], block: { [unowned self] (event) in
+            guard let youboraManager = self.youboraManager else { return }
+            youboraManager.currentBitrate = event.currentBitrate?.doubleValue
+            self.postEventLogWithMessage(message: "playbackParamsUpdated event: \(event)")
         })
 
-        self.player.addObserver(self, events: [PlayerEvent.stateChanged]) { (event) in
-            
+        self.messageBus.addObserver(self, events: [PlayerEvent.stateChanged]) { [unowned self] (event) in
+            guard let youboraManager = self.youboraManager else { return }
             if let stateChanged = event as? PlayerEvent.StateChanged {
-
                 switch event.newState {
                 case .buffering:
-                    self.youboraManager.bufferingHandler()
-                    self.postEventLogWithMessage(message: "Event info: Buffering")
+                    youboraManager.bufferingHandler()
+                    self.postEventLogWithMessage(message: "Buffering event: ֿ\(event)")
                     break
-                default:
-                    
-                    break
+                default: break
                 }
                 
                 switch event.oldState {
                 case .buffering:
-                    self.youboraManager.bufferedHandler()
-                    self.postEventLogWithMessage(message: "Event info: Buffered")
+                    youboraManager.bufferedHandler()
+                    self.postEventLogWithMessage(message: "Buffered event: \(event)")
                     break
-                default:
-                    break
+                default: break
                 }
             }
         }
         
-        self.messageBus?.addObserver(self, events: AdEvent.allEventTypes, block: { (info) in
-            
-            PKLog.trace("Ads event info: \(info)")
-
-            self.postEventLogWithMessage(message: "Event info: \(info)")
+        self.messageBus.addObserver(self, events: AdEvent.allEventTypes, block: { [unowned self] (event) in
+            self.postEventLogWithMessage(message: "Ads event event: \(event)")
         })
     }
     
     private func postEventLogWithMessage(message: String) {
+        PKLog.trace(message)
         let eventLog = YouboraEvent.YouboraReportSent(message: message as NSString)
-        self.messageBus?.post(eventLog)
-    }
-    
-    @objc private func didStartPlaying() {
-        PKLog.trace("didStartPlaying")
-        self.youboraManager.joinHandler()
+        self.messageBus.post(eventLog)
     }
 }
+

--- a/Plugins/Youbora/YouboraPlugin.swift
+++ b/Plugins/Youbora/YouboraPlugin.swift
@@ -26,10 +26,10 @@ public class YouboraPlugin: PKPlugin {
 
     }
     
-    public func load(player: Player, mediaConfig: MediaEntry, pluginConfig: Any?, messageBus: MessageBus) {
+    public func load(player: Player, pluginConfig: Any?, messageBus: MessageBus) {
     
         self.messageBus = messageBus
-        self.mediaEntry = mediaConfig
+//        self.mediaEntry = mediaConfig
         
         if let aConfig = pluginConfig as? AnalyticsConfig {
             self.config = aConfig

--- a/Plugins/Youbora/YouboraPlugin.swift
+++ b/Plugins/Youbora/YouboraPlugin.swift
@@ -12,14 +12,14 @@ import AVFoundation
 
 public class YouboraPlugin: PKPlugin {
 
-    private var player: Player
-    private var messageBus: MessageBus
+    private unowned var player: Player
+    private unowned var messageBus: MessageBus
     private var config: AnalyticsConfig?
     private var youboraManager : YouboraManager?
     private var isFirstPlay = true
     
     public static var pluginName: String = "YouboraPlugin"
-    public var mediaEntry: MediaEntry?
+    public weak var mediaEntry: MediaEntry?
     
     /************************************************************/
     // MARK: - PKPlugin


### PR DESCRIPTION
* changed PlayKitManager sharedInstance to shared in swift (in objective-c it is still sharedInstance), much more swifter.
* separated `PlayerConfig` to `MediaConfig` that will be used for preparing the player and `PluginConfig` that will be used for loading the player.
Also created a `PlayerConfig` object as a composition for `MediaConfig` and `PluginConfig`.
* changed player’s prepare to receive `MediaConfig` instead of player config.
* changed player duration from double to TimeInterval (time interval is also a double but make more sense for duration to be time related).
* `PlayerLoader` now loads the plugin media entry when prepare is called and loader.load method just initializes the plugin.
* PKPlugin was added `mediaEntry` property and `onLoad` + `onUpdateMedia` methods to enable media entry changes and loading.
* Fixed Youbora manager get player version, was returning same version, now returns the real version.
* Fixed issue where Youbora plugin could crash if media entry was nil.