### PR TITLE
Fix to prevent initializing `PlayKitManager` from outside 

### DIFF
--- a/Classes/Managers/PlayKitManager.swift
+++ b/Classes/Managers/PlayKitManager.swift
@@ -18,7 +18,9 @@ public class PlayKitManager: NSObject {
 
     // private init to prevent initializing this singleton
     private override init() {
-        super.init()
+        if type(of: self) != PlayKitManager.self {
+            fatalError("Private initializer, use shared instance instead")
+        }
     }
     
     public static let versionString: String = Bundle(for: PlayKitManager.self)


### PR DESCRIPTION
prevents initializing `PlayKitManager` from outside in swift and objc.