### PR TITLE
Fixes memory leak created by Apple’s interoperability

### DIFF
--- a/Classes/Managers/PlayKitManager.swift
+++ b/Classes/Managers/PlayKitManager.swift
@@ -50,8 +50,11 @@ public class PlayKitManager: NSObject {
         return loader
     }
     
-    public func registerPlugin(_ pluginClass: PKPlugin.Type) {
-        pluginRegistry[pluginClass.pluginName] = pluginClass
+    public func registerPlugin(_ pluginClass: Plugin.Type) {
+        guard let pluginType = pluginClass as? PKPlugin.Type else {
+            fatalError("plugin class must be of type PKPlugin")
+        }
+        pluginRegistry[pluginType.pluginName] = pluginType
     }
     
     func createPlugin(name: String, player: Player, pluginConfig: Any?, messageBus: MessageBus) -> PKPlugin? {

--- a/Classes/Player/AVPlayerEngine.swift
+++ b/Classes/Player/AVPlayerEngine.swift
@@ -217,6 +217,7 @@ class AVPlayerEngine: AVPlayer {
         self.onEventBlock = nil
         // removes app state observer
         AppStateSubject.sharedInstance.remove(observer: self)
+        self.replaceCurrentItem(with: nil)
         self.isDestroyed = true
     }
     

--- a/Classes/Plugins/PKPlugin.swift
+++ b/Classes/Plugins/PKPlugin.swift
@@ -9,8 +9,19 @@
 import UIKit
 import AVFoundation
 
+/**
+ Used as a workaround for Apple bug with swift interoperability.
+ 
+ There is an issue with initializing an object based on a protocol.Type with @objc attribute.
+ Therefore we use a wrapper protocol for PKPlugin with @objc and then casting to a PKPlugin without the @objc attribute.
+ 
+ - important:
+ **should not be used! use PKPlugin to add a plugin**
+ */
+@objc public protocol Plugin {}
+
 /// The `PKPlugin` protocol defines all the properties and methods required to define a plugin object.
-@objc public protocol PKPlugin {
+public protocol PKPlugin: Plugin {
     /// The plugin name.
     static var pluginName: String { get }
     /// The associated media entry.


### PR DESCRIPTION
Fixes memory leak created by Apple’s interoperability for initializing object from protocol.Type with @objc attribute