### PR TITLE
Made SessionProviders and MediaEntryProviders objective-c compatible

### DIFF
--- a/Classes/Network/SessionProvider.swift
+++ b/Classes/Network/SessionProvider.swift
@@ -8,12 +8,12 @@
 
 import UIKit
 
-public protocol SessionProvider {
+@objc public protocol SessionProvider: class {
     
     var serverURL: String { get }
     var partnerId: Int64 { get }
     
-    func loadKS(completion: @escaping (_ result :Result<String>) -> Void)
+    func loadKS(completion: @escaping (String?, Error?) -> Void)
 }
 
 

--- a/Classes/Providers/MediaEntryProvider.swift
+++ b/Classes/Providers/MediaEntryProvider.swift
@@ -9,7 +9,7 @@
 import UIKit
 
 
-public protocol MediaEntryProvider {
+@objc public protocol MediaEntryProvider {
     /**
      This method is triggering the creation of media base on custom parameters and actions.
      
@@ -31,7 +31,7 @@ public protocol MediaEntryProvider {
      ```
      
      */
-    func loadMedia(callback: @escaping (Result<MediaEntry>) -> Void)
+    func loadMedia(callback: @escaping (MediaEntry?, Error?) -> Void)
     
     
     func cancel()

--- a/Classes/Providers/Mock/MockMediaProvider.swift
+++ b/Classes/Providers/Mock/MockMediaProvider.swift
@@ -11,7 +11,7 @@ import SwiftyJSON
 
 
 
-public class MockMediaEntryProvider: MediaEntryProvider {
+@objc public class MockMediaEntryProvider: NSObject, MediaEntryProvider {
   
 
     
@@ -47,7 +47,7 @@ public class MockMediaEntryProvider: MediaEntryProvider {
         return self
     }
     
-    public init(){
+    public override init(){
         
     }
     
@@ -58,11 +58,11 @@ public class MockMediaEntryProvider: MediaEntryProvider {
     }
 
     
-    public func loadMedia(callback: @escaping (Result<MediaEntry>) -> Void){
+    public func loadMedia(callback: @escaping (MediaEntry?, Error?) -> Void){
         
         
         guard let id = self.id else {
-            callback(Result(data: nil, error: MockError.invalidParam(paramName: "id")))
+            callback(nil, MockError.invalidParam(paramName: "id"))
             return
         }
         
@@ -71,11 +71,11 @@ public class MockMediaEntryProvider: MediaEntryProvider {
             json = JSON(self.content)
         }else if self.url != nil{
             guard let stringPath = self.url?.absoluteString else {
-                 callback(Result(data: nil, error: MockError.invalidParam(paramName: "url")))
+                 callback(nil, MockError.invalidParam(paramName: "url"))
                 return
             }
             guard  let data = NSData(contentsOfFile: stringPath)  else {
-                 callback(Result(data: nil, error: MockError.fileIsEmptyOrNotFound))
+                 callback(nil, MockError.fileIsEmptyOrNotFound)
                 return
             }
             json = JSON(data: data as Data)
@@ -83,25 +83,25 @@ public class MockMediaEntryProvider: MediaEntryProvider {
         
         
         guard  let jsonContent = json else {
-            callback(Result(data: nil, error: MockError.unableToParseJSON))
+            callback(nil, MockError.unableToParseJSON)
             return
         }
         
         let loderInfo = LoaderInfo(id: id, content: jsonContent)
         
         guard  loderInfo.content != .null  else {
-            callback(Result(data: nil, error: MockError.unableToParseJSON))
+            callback(nil, MockError.unableToParseJSON)
             return
         }
         
         let jsonObject: JSON = loderInfo.content[loderInfo.id]
         guard jsonObject != .null else {
-            callback(Result(data: nil, error:MockError.mediaNotFound))
+            callback(nil, MockError.mediaNotFound)
             return
         }
         
         let mediaEntry : MediaEntry? = MediaEntry(json: jsonObject.object)
-        callback(Result(data: mediaEntry, error: nil))
+        callback(mediaEntry, nil)
     }
     
     public func cancel() {

--- a/Classes/Providers/OTT/OTTMediaProvider.swift
+++ b/Classes/Providers/OTT/OTTMediaProvider.swift
@@ -9,7 +9,7 @@
 import UIKit
 import SwiftyJSON
 
-public class OTTMediaProvider: MediaEntryProvider {
+@objc public class OTTMediaProvider: NSObject, MediaEntryProvider {
     
     
     var sessionProvider: SessionProvider?
@@ -29,7 +29,7 @@ public class OTTMediaProvider: MediaEntryProvider {
     }
     
     
-    public init(){
+    public override init(){
         
     }
     
@@ -74,14 +74,14 @@ public class OTTMediaProvider: MediaEntryProvider {
         
     }
     
-    public func loadMedia(callback: @escaping (Result<MediaEntry>) -> Void) {
+    public func loadMedia(callback: @escaping (MediaEntry?, Error?) -> Void) {
         
         
         guard let sessionProvider = self.sessionProvider,
             let mediaId = self.mediaId,
             let type = self.type
             else {
-                callback(Result(data: nil, error: Err.invalidInputParams))
+                callback(nil, Err.invalidInputParams)
                 return
         }
         
@@ -104,11 +104,10 @@ public class OTTMediaProvider: MediaEntryProvider {
         
     }
     
-    func startLoad(loader:LoaderInfo,callback: @escaping (Result<MediaEntry>) -> Void) {
-        loader.sessionProvider.loadKS { (r:Result<String>) in
-            
-            guard let ks = r.data else {
-                callback(Result(data: nil, error: Err.invalidKS))
+    func startLoad(loader:LoaderInfo, callback: @escaping (MediaEntry?, Error?) -> Void) {
+        loader.sessionProvider.loadKS { (ks, error) in
+            guard let ks = ks else {
+                callback(nil, Err.invalidKS)
                 return
             }
             
@@ -117,7 +116,7 @@ public class OTTMediaProvider: MediaEntryProvider {
                 .set(completion: { (r:Response) in
                     
                     guard let data = r.data else {
-                        callback(Result(data: nil, error: Err.mediaNotFound))
+                        callback(nil, Err.mediaNotFound)
                         return
                     }
                     
@@ -125,7 +124,7 @@ public class OTTMediaProvider: MediaEntryProvider {
                     do {
                         object = try OTTResponseParser.parse(data: data)
                     }catch{
-                        callback(Result(data: nil, error: error))
+                        callback(nil, error)
                     }
                     
                     if let asset = object as? OTTAsset {
@@ -150,9 +149,9 @@ public class OTTMediaProvider: MediaEntryProvider {
                             }
                         }
                         
-                        callback(Result(data: mediaEntry, error: nil))
+                        callback(mediaEntry, nil)
                     }else{
-                        callback(Result(data: nil, error: Err.mediaNotFound))
+                        callback(nil, Err.mediaNotFound)
                     }
                     
                 })

--- a/Classes/Providers/OTT/Session/OTTSessionManager.swift
+++ b/Classes/Providers/OTT/Session/OTTSessionManager.swift
@@ -8,7 +8,7 @@
 
 import UIKit
 
-public class OTTSessionManager: SessionProvider {
+@objc public class OTTSessionManager: NSObject, SessionProvider {
     
     
     enum SessionManagerError: Error{
@@ -153,18 +153,18 @@ public class OTTSessionManager: SessionProvider {
     }
     
     
-    public func loadKS(completion: @escaping (_ result :Result<String>) -> Void) {
+    public func loadKS(completion: @escaping (String?, Error?) -> Void) {
         let now = Date()
         
         if let expiration = self.tokenExpiration, expiration.timeIntervalSince(now) > saftyMargin {
-            completion(Result(data:self.ks, error: nil))
+            completion(self.ks, nil)
         }else{
             
             self.refreshKS(completion: completion)
         }
     }
     
-    public func refreshKS(completion: @escaping (_ result :Result<String>) -> Void){
+    public func refreshKS(completion: @escaping (String?, Error?) -> Void){
         
         if let refreshToken = self.refreshToken, let ks = self.ks{
             
@@ -180,7 +180,7 @@ public class OTTSessionManager: SessionProvider {
                         do{
                         response = try OTTMultiResponseParser.parse(data: data)
                         }catch{
-                            completion(Result(data: nil, error: error))
+                            completion(nil, error)
                         }
                         
                         if let response = response, response.count == 2, let loginSession = response[0] as? OTTLoginSession, let session = response[1] as? OTTSession{
@@ -189,14 +189,14 @@ public class OTTSessionManager: SessionProvider {
                             self.refreshToken = loginSession.refreshToken
                             self.tokenExpiration = session.tokenExpiration
                             
-                            completion(Result(data: self.ks, error: nil))
+                            completion(self.ks, nil)
                             
                         }else{
-                            completion(Result(data: nil, error: SessionManagerError.failedToRefreshKS))
+                            completion(nil, SessionManagerError.failedToRefreshKS)
                         }
                         
                     }else{
-                        completion(Result(data: nil, error: SessionManagerError.failedToRefreshKS))
+                        completion(nil, SessionManagerError.failedToRefreshKS)
                     }
                     
                 }))
@@ -205,14 +205,14 @@ public class OTTSessionManager: SessionProvider {
                     self.executor.send(request: request)
                     
                 }else{
-                    completion(Result(data: nil, error: SessionManagerError.failedToBuildRefreshRequest))
+                    completion(nil, SessionManagerError.failedToBuildRefreshRequest)
                 }
                 
             }else{
-               completion(Result(data: nil, error: SessionManagerError.invalidRefreshCallResponse))
+               completion(nil, SessionManagerError.invalidRefreshCallResponse)
             }
         }else{
-            completion(Result(data: nil, error: SessionManagerError.noRefreshTokenOrTokenToRefresh))
+            completion(nil, SessionManagerError.noRefreshTokenOrTokenToRefresh)
         }
 
     }

--- a/Classes/Providers/OVP/Session/OVPSessionManager.swift
+++ b/Classes/Providers/OVP/Session/OVPSessionManager.swift
@@ -8,7 +8,7 @@
 
 import UIKit
 
-public class OVPSessionManager: SessionProvider {
+@objc public class OVPSessionManager: NSObject, SessionProvider {
     
     
     public enum SessionManagerError: Error{
@@ -59,9 +59,9 @@ public class OVPSessionManager: SessionProvider {
         self.init(serverURL: serverURL, partnerId: partnerId, executor: executor)
     }
     
-    public func loadKS(completion: @escaping (_ result :Result<String>) -> Void){
+    public func loadKS(completion: @escaping (String?, Error?) -> Void){
         if let ks = self.ks, self.tokenExpiration?.compare(Date()) == ComparisonResult.orderedDescending {
-                completion(Result(data: ks))
+                completion(ks, nil)
         }else{
             
             self.ks = nil
@@ -86,13 +86,13 @@ public class OVPSessionManager: SessionProvider {
     }
     
     
-    func ensureKSAfterRefresh(e:Error?,completion: @escaping (_ result :Result<String>) -> Void) -> Void {
+    func ensureKSAfterRefresh(e:Error?,completion: @escaping (String?, Error?) -> Void) -> Void {
         if let ks = self.ks {
-            completion(Result(data: ks))
+            completion(ks, nil)
         }else if let error = e {
-            completion(Result(error: error))
+            completion(nil, error)
         }else{
-            completion(Result(error: SessionManagerError.ksExpired))
+            completion(nil, SessionManagerError.ksExpired)
         }
     }
     

--- a/Classes/Providers/OVP/SimpleOVPSessionProvider.swift
+++ b/Classes/Providers/OVP/SimpleOVPSessionProvider.swift
@@ -19,7 +19,7 @@ import UIKit
      }
  
  */
-public class SimpleOVPSessionProvider: SessionProvider {
+@objc public class SimpleOVPSessionProvider: NSObject, SessionProvider {
     public let serverURL: String
     public let partnerId: Int64
     public var ks: String?
@@ -37,7 +37,7 @@ public class SimpleOVPSessionProvider: SessionProvider {
         self.ks = ks
     }
     
-    public func loadKS(completion: @escaping (Result<String>) -> Void) {
-        completion(Result(data: ks, error: nil))
+    public func loadKS(completion: @escaping (String?, Error?) -> Void) {
+        completion(ks, nil)
     }
 }


### PR DESCRIPTION
Swift generics are incompatible with Objective-C, so the protocol methods:
```swift
    func loadKS(completion: @escaping (_ result :Result<String>) -> Void)
    func loadMedia(callback: @escaping (Result<MediaEntry>) -> Void)
```
Could not be translated to objc, which causes the entire protocol to be incompatible.

The fix is changing above methods to:
```swift
    func loadKS(completion: @escaping (String?, Error?) -> Void)
    func loadMedia(callback: @escaping (MediaEntry?, Error?) -> Void)
```