### PR TITLE
FEM-1124

### DIFF
--- a/Addons/GoogleCast/AdInfoParser.swift
+++ b/Addons/GoogleCast/AdInfoParser.swift
@@ -26,8 +26,7 @@ public class AdInfoParser: NSObject, GCKRemoteMediaClientAdInfoParserDelegate {
         
          guard let customData = mediaStatus.customData as? [String:Any],
             let adsInfo = customData["adsInfo"] as? [String:Any],
-            let metaData : AdsMetadata = AdsMetadata(dict: adsInfo)
-            else{
+            let metaData : AdsMetadata = AdsMetadata(dict: adsInfo) else {
                 PKLog.warning("No Ads info from receiver")
                 return false
         }
@@ -44,10 +43,9 @@ public class AdInfoParser: NSObject, GCKRemoteMediaClientAdInfoParserDelegate {
         guard let customData = mediaStatus.customData as? [String:Any],
             let adsInfo = customData["adsInfo"] as? [String:Any],
             let adsData : AdsMetadata = AdsMetadata(dict: adsInfo),
-            let adsBreakInfo = adsData.adsBreakInfo
-            else {
-               PKLog.warning("No Ads info from receiver")
-             return nil
+            let adsBreakInfo = adsData.adsBreakInfo else {
+                PKLog.warning("No Ads info from receiver")
+                return nil
         }
         
         let adsBreakInfoArray = adsBreakInfo.map({ GCKAdBreakInfo(playbackPosition: TimeInterval($0)) })

--- a/Classes/Managers/LocalAssetsManager.swift
+++ b/Classes/Managers/LocalAssetsManager.swift
@@ -97,7 +97,10 @@ public class LocalAssetsManager: NSObject {
     /// the capabilities of the device.
     public func getPreferredDownloadableMediaSource(for mediaEntry: MediaEntry) -> MediaSource? {
 
-        guard let sources = mediaEntry.sources else {return nil}
+        guard let sources = mediaEntry.sources else {
+            PKLog.error("no media sources in mediaEntry!")
+            return nil
+        }
         
         // On iOS 10 and up: HLS (clear or FP), MP4, WVM
         // Below iOS10: HLS (only clear), MP4, WVM
@@ -119,6 +122,7 @@ public class LocalAssetsManager: NSObject {
             return source
         }
         
+        PKLog.error("no preferred downloadable media sources!")
         return nil
     }
 

--- a/Classes/Managers/LocalAssetsManager.swift
+++ b/Classes/Managers/LocalAssetsManager.swift
@@ -122,7 +122,7 @@ public class LocalAssetsManager: NSObject {
             return source
         }
         
-        PKLog.error("no preferred downloadable media sources!")
+        PKLog.error("no downloadable media sources!")
         return nil
     }
 

--- a/Classes/Managers/PlayKitManager.swift
+++ b/Classes/Managers/PlayKitManager.swift
@@ -55,11 +55,11 @@ public class PlayKitManager: NSObject {
         pluginRegistry[pluginType.pluginName] = pluginType
     }
     
-    func createPlugin(name: String, player: Player, pluginConfig: Any?, messageBus: MessageBus) -> PKPlugin? {
-        let pluginClass = pluginRegistry[name]
-        guard pluginClass != nil else {
-            return nil
+    func createPlugin(name: String, player: Player, pluginConfig: Any?, messageBus: MessageBus) throws -> PKPlugin {
+        guard let pluginClass = pluginRegistry[name] else {
+            PKLog.error("plugin with name: \(name) doesn't exist in pluginRegistry")
+            throw PKPluginError.failedToCreatePlugin
         }
-        return pluginClass?.init(player: player, pluginConfig: pluginConfig, messageBus: messageBus)
+        return pluginClass.init(player: player, pluginConfig: pluginConfig, messageBus: messageBus)
     }
 }

--- a/Classes/Managers/PlayKitManager.swift
+++ b/Classes/Managers/PlayKitManager.swift
@@ -48,11 +48,8 @@ public class PlayKitManager: NSObject {
         return loader
     }
     
-    public func registerPlugin(_ pluginClass: Plugin.Type) {
-        guard let pluginType = pluginClass as? PKPlugin.Type else {
-            fatalError("plugin class must be of type PKPlugin")
-        }
-        pluginRegistry[pluginType.pluginName] = pluginType
+    public func registerPlugin(_ pluginClass: BasePlugin.Type) {
+        pluginRegistry[pluginClass.pluginName] = pluginClass
     }
     
     func createPlugin(name: String, player: Player, pluginConfig: Any?, messageBus: MessageBus) throws -> PKPlugin {

--- a/Classes/Managers/PlayKitManager.swift
+++ b/Classes/Managers/PlayKitManager.swift
@@ -55,10 +55,10 @@ public class PlayKitManager: NSObject {
         pluginRegistry[pluginType.pluginName] = pluginType
     }
     
-    func createPlugin(name: String, player: Player, pluginConfig: Any?, messageBus: MessageBus) throws -> PKPlugin {
+    func createPlugin(name: String, player: Player, pluginConfig: Any?, messageBus: MessageBus) -> PKPlugin {
         guard let pluginClass = pluginRegistry[name] else {
             PKLog.error("plugin with name: \(name) doesn't exist in pluginRegistry")
-            throw PKPluginError.failedToCreatePlugin
+            self.messageBus.post(PlayerEvent.Error(nsError: PKPluginError.failedToCreatePlugin.asNSError))
         }
         return pluginClass.init(player: player, pluginConfig: pluginConfig, messageBus: messageBus)
     }

--- a/Classes/Managers/PlayKitManager.swift
+++ b/Classes/Managers/PlayKitManager.swift
@@ -55,10 +55,10 @@ public class PlayKitManager: NSObject {
         pluginRegistry[pluginType.pluginName] = pluginType
     }
     
-    func createPlugin(name: String, player: Player, pluginConfig: Any?, messageBus: MessageBus) -> PKPlugin {
+    func createPlugin(name: String, player: Player, pluginConfig: Any?, messageBus: MessageBus) throws -> PKPlugin {
         guard let pluginClass = pluginRegistry[name] else {
             PKLog.error("plugin with name: \(name) doesn't exist in pluginRegistry")
-            self.messageBus.post(PlayerEvent.Error(nsError: PKPluginError.failedToCreatePlugin.asNSError))
+            throw PKPluginError.failedToCreatePlugin
         }
         return pluginClass.init(player: player, pluginConfig: pluginConfig, messageBus: messageBus)
     }

--- a/Classes/PKError.swift
+++ b/Classes/PKError.swift
@@ -89,36 +89,18 @@ extension PKError where Self: RawRepresentable, Self.RawValue == String {
 /************************************************************/
 
 // general userInfo keys.
-extension PKError {
-    var RootErrorKey: String {
-        return "rootError"
-    }
-    
-    var RootCodeKey: String {
-        return "rootCode"
-    }
-    
-    var RootDomainKey: String {
-        return "rootDomain"
-    }
-}
-
-// general plugin error userInfo keys.
-extension PKPluginError  {
-    var PluginNameKey: String {
-        return "pluginName"
-    }
+struct PKErrorKeys {
+    static let RootErrorKey = "rootError"
+    static let RootCodeKey = "rootCode"
+    static let RootDomainKey = "rootDomain"
 }
 
 /************************************************************/
 // MARK: - PlayKit Error Domains
 /************************************************************/
 
-@objc public class PKErrorDomain: NSObject { // public interface
-    public static let IMA = "com.kaltura.playkit.error.ima"
-    public static let Plugin = "com.kaltura.playkit.error.plugins"
-    public static let Player = "com.kaltura.playkit.error.player"
-    public static let Youbora = "com.kaltura.playkit.error.youbora"
-    public static let AnalyticsPlugin = "com.kaltura.playkit.error.analyticsPlugin"
+@objc public class PKErrorDomain: NSObject {
+    public static let Plugin = PKPluginError.Domain
+    public static let Player = PlayerError.Domain
 }
 

--- a/Classes/PKError.swift
+++ b/Classes/PKError.swift
@@ -7,6 +7,98 @@
 //
 
 import Foundation
+import AVFoundation
+
+
+
+/************************************************************/
+// MARK: - PlayerError
+/************************************************************/
+
+/// `PlayerError` represents player errors.
+enum PlayerError: PKError {
+    
+    case failedToLoadAssetFromKeys(rootError: NSError?)
+    case assetNotPlayable
+    case failedToPlayToEndTime(rootError: NSError)
+    case playerItemErrorLogEvent(errorLogEvent: AVPlayerItemErrorLogEvent)
+    
+    static let Domain = "com.kaltura.playkit.error.player"
+    
+    var code: Int {
+        switch self {
+        case .failedToLoadAssetFromKeys: return 7000
+        case .assetNotPlayable: return 7001
+        case .failedToPlayToEndTime: return 7002
+        case .playerItemErrorLogEvent: return 7003
+        }
+    }
+    
+    var errorDescription: String {
+        switch self {
+        case .failedToLoadAssetFromKeys: return "Can't use this AVAsset because one of it's keys failed to load"
+        case .assetNotPlayable: return "Can't use this AVAsset because it isn't playable"
+        case .failedToPlayToEndTime: return "Item failed to play to its end time"
+        case .playerItemErrorLogEvent(let errorLogEvent): return errorLogEvent.errorComment ?? ""
+        }
+    }
+    
+    var userInfo: [String: Any] {
+        switch self {
+        case .failedToLoadAssetFromKeys(let rootError): return [PKErrorKeys.RootErrorKey : rootError]
+        case .assetNotPlayable: return [:]
+        case .failedToPlayToEndTime(let rootError): return [PKErrorKeys.RootErrorKey : rootError]
+        case .playerItemErrorLogEvent(let errorLogEvent):
+            return [
+                PKErrorKeys.RootCodeKey : errorLogEvent.errorStatusCode,
+                PKErrorKeys.RootDomainKey : errorLogEvent.errorDomain
+            ]
+        }
+    }
+}
+
+/************************************************************/
+// MARK: - PKPluginError
+/************************************************************/
+
+/// `PKPluginError` represents plugins errors.
+enum PKPluginError: PKError {
+    
+    case failedToCreatePlugin
+    case missingPluginConfig(pluginName: String)
+    
+    static let Domain = "com.kaltura.playkit.error.plugins"
+    
+    var code: Int {
+        switch self {
+        case .failedToCreatePlugin: return 2000
+        case .missingPluginConfig: return 2001
+        }
+    }
+    
+    var errorDescription: String {
+        switch self {
+        case .failedToCreatePlugin: return "failed to create plugin, doesn't exist in registry"
+        case .missingPluginConfig(let pluginName): return "Missing plugin config for plugin: \(pluginName)"
+        }
+    }
+    
+    var userInfo: [String: Any] {
+        switch self {
+        case .failedToCreatePlugin: return [:]
+        case .missingPluginConfig(let pluginName): return [PKErrorKeys.PluginNameKey : pluginName]
+        }
+    }
+}
+
+// general plugin error userInfo keys.
+extension PKErrorKeys {
+    static let PluginNameKey = "pluginName"
+}
+
+/************************************************************/
+// MARK: - PKError
+/************************************************************/
 
 /// `PKError` is used as a protocol for errors that can be converted to `NSError` if need be.
 /// - important: should be used on enums for best results on multiple cases!

--- a/Classes/PKError.swift
+++ b/Classes/PKError.swift
@@ -1,0 +1,124 @@
+//
+//  PKError.swift
+//  Pods
+//
+//  Created by Gal Orlanczyk on 19/02/2017.
+//
+//
+
+import Foundation
+
+/// `PKError` is used as a protocol for errors that can be converted to `NSError` if need be.
+/// - important: should be used on enums for best results on multiple cases!
+protocol PKError: Error, CustomStringConvertible {
+    
+    /// The error domain (used for creating `NSError`)
+    static var Domain: String { get }
+    
+    /**
+     The error code.
+     use `switch self` to retrive the value in **enums**.
+     
+     ````
+     var code: Int {
+        switch self {
+        case .one: return 1
+        case .two: return 2
+        }
+     }
+     ````
+     */
+    var code: Int { get }
+    
+    /// The error description.
+    var errorDescription: String { get }
+    
+    /**
+     Dictionary object to hold all params of the case.
+     
+     Should take all associated values and create a dictionary for them.
+     
+     For example in **enum error** when we have 2 cases:
+     
+     * .one(error: NSError, url: URL)
+     * .two(error: NSError))
+     
+     ````
+     var userInfo: [String : Any] {
+        switch self {
+        case .one(let rootError, let url):
+        return ["root": rootError, "url": url]
+        case .two(let rootError):
+        return ["root": rootError]
+        }
+     }
+     ````
+     */
+    var userInfo: [String : Any] { get }
+    
+    /// creates an `NSError` from the selected case.
+    var asNSError: NSError { get }
+}
+
+/************************************************************/
+// MARK: - PKError default implementations
+/************************************************************/
+
+extension PKError {
+    /// description string
+    var description: String {
+        return "\(type(of: self)) ,domain: \(type(of: self).Domain), errorCode: \(self.code)"
+    }
+    
+    /// creates an `NSError` from the selected case.
+    var asNSError: NSError {
+        var userInfo = self.userInfo
+        userInfo[NSLocalizedDescriptionKey] = self.errorDescription
+        return NSError(domain: Self.Domain, code: self.code, userInfo: userInfo)
+    }
+}
+
+extension PKError where Self: RawRepresentable, Self.RawValue == String {
+    var description: String {
+        return "\(self.rawValue), domain: \(type(of: self).Domain), errorCode: \(self.code)"
+    }
+}
+
+/************************************************************/
+// MARK: - PKError UserInfo Keys
+/************************************************************/
+
+// general userInfo keys.
+extension PKError {
+    var RootErrorKey: String {
+        return "rootError"
+    }
+    
+    var RootCodeKey: String {
+        return "rootCode"
+    }
+    
+    var RootDomainKey: String {
+        return "rootDomain"
+    }
+}
+
+// general plugin error userInfo keys.
+extension PKPluginError  {
+    var PluginNameKey: String {
+        return "pluginName"
+    }
+}
+
+/************************************************************/
+// MARK: - PlayKit Error Domains
+/************************************************************/
+
+@objc public class PKErrorDomain: NSObject { // public interface
+    public static let IMA = "com.kaltura.playkit.error.ima"
+    public static let Plugin = "com.kaltura.playkit.error.plugins"
+    public static let Player = "com.kaltura.playkit.error.player"
+    public static let Youbora = "com.kaltura.playkit.error.youbora"
+    public static let AnalyticsPlugin = "com.kaltura.playkit.error.analyticsPlugin"
+}
+

--- a/Classes/Player/AVPlayerEngine.swift
+++ b/Classes/Player/AVPlayerEngine.swift
@@ -23,10 +23,10 @@ enum PlayerError: PKError {
     
     var code: Int {
         switch self {
-        case .failedToLoadAssetFromKeys: return 1000
-        case .assetNotPlayable: return 1001
-        case .failedToPlayToEndTime: return 1002
-        case .playerItemErrorLogEvent: return 1003
+        case .failedToLoadAssetFromKeys: return 7000
+        case .assetNotPlayable: return 7001
+        case .failedToPlayToEndTime: return 7002
+        case .playerItemErrorLogEvent: return 7003
         }
     }
     

--- a/Classes/Player/AVPlayerEngine.swift
+++ b/Classes/Player/AVPlayerEngine.swift
@@ -11,48 +11,6 @@ import AVFoundation
 import AVKit
 import CoreMedia
 
-/// `PlayerError` represents player errors.
-enum PlayerError: PKError {
-    
-    case failedToLoadAssetFromKeys(rootError: NSError?)
-    case assetNotPlayable
-    case failedToPlayToEndTime(rootError: NSError)
-    case playerItemErrorLogEvent(errorLogEvent: AVPlayerItemErrorLogEvent)
-    
-    static let Domain = "com.kaltura.playkit.error.player"
-    
-    var code: Int {
-        switch self {
-        case .failedToLoadAssetFromKeys: return 7000
-        case .assetNotPlayable: return 7001
-        case .failedToPlayToEndTime: return 7002
-        case .playerItemErrorLogEvent: return 7003
-        }
-    }
-    
-    var errorDescription: String {
-        switch self {
-        case .failedToLoadAssetFromKeys: return "Can't use this AVAsset because one of it's keys failed to load"
-        case .assetNotPlayable: return "Can't use this AVAsset because it isn't playable"
-        case .failedToPlayToEndTime: return "Item failed to play to its end time"
-        case .playerItemErrorLogEvent(let errorLogEvent): return errorLogEvent.errorComment ?? ""
-        }
-    }
-    
-    var userInfo: [String: Any] {
-        switch self {
-        case .failedToLoadAssetFromKeys(let rootError): return [PKErrorKeys.RootErrorKey : rootError]
-        case .assetNotPlayable: return [:]
-        case .failedToPlayToEndTime(let rootError): return [PKErrorKeys.RootErrorKey : rootError]
-        case .playerItemErrorLogEvent(let errorLogEvent):
-            return [
-                PKErrorKeys.RootCodeKey : errorLogEvent.errorStatusCode,
-                PKErrorKeys.RootDomainKey : errorLogEvent.errorDomain
-            ]
-        }
-    }
-}
-
 /// An AVPlayerEngine is a controller used to manage the playback and timing of a media asset.
 /// It provides the interface to control the player’s behavior such as its ability to play, pause, and seek to various points in the timeline.
 class AVPlayerEngine: AVPlayer {

--- a/Classes/Player/AVPlayerEngine.swift
+++ b/Classes/Player/AVPlayerEngine.swift
@@ -11,7 +11,7 @@ import AVFoundation
 import AVKit
 import CoreMedia
 
-/// `AVPlayerEngineError` represents player engine errors.
+/// `PlayerError` represents player errors.
 enum PlayerError: PKError {
     
     case failedToLoadAssetFromKeys(rootError: NSError?)

--- a/Classes/Player/AVPlayerEngine.swift
+++ b/Classes/Player/AVPlayerEngine.swift
@@ -19,7 +19,7 @@ enum PlayerError: PKError {
     case failedToPlayToEndTime(rootError: NSError)
     case playerItemErrorLogEvent(errorLogEvent: AVPlayerItemErrorLogEvent)
     
-    static let Domain = PKErrorDomain.Player
+    static let Domain = "com.kaltura.playkit.error.player"
     
     var code: Int {
         switch self {
@@ -41,13 +41,13 @@ enum PlayerError: PKError {
     
     var userInfo: [String: Any] {
         switch self {
-        case .failedToLoadAssetFromKeys(let rootError): return [RootErrorKey : rootError]
+        case .failedToLoadAssetFromKeys(let rootError): return [PKErrorKeys.RootErrorKey : rootError]
         case .assetNotPlayable: return [:]
-        case .failedToPlayToEndTime(let rootError): return [RootErrorKey : rootError]
+        case .failedToPlayToEndTime(let rootError): return [PKErrorKeys.RootErrorKey : rootError]
         case .playerItemErrorLogEvent(let errorLogEvent):
             return [
-                RootCodeKey : errorLogEvent.errorStatusCode,
-                RootDomainKey : errorLogEvent.errorDomain
+                PKErrorKeys.RootCodeKey : errorLogEvent.errorStatusCode,
+                PKErrorKeys.RootDomainKey : errorLogEvent.errorDomain
             ]
         }
     }

--- a/Classes/Player/AssetBuilder.swift
+++ b/Classes/Player/AssetBuilder.swift
@@ -55,7 +55,7 @@ class AssetBuilder {
             return (source, DRMSupport.widevineClassicHandler!)
         }
         
-        PKLog.error("no preferred media sources!")
+        PKLog.error("no playable media sources!")
         return nil
     }
 

--- a/Classes/Player/AssetBuilder.swift
+++ b/Classes/Player/AssetBuilder.swift
@@ -20,7 +20,10 @@ class AssetBuilder {
 
     public func getPreferredMediaSource() -> (MediaSource, AssetHandler.Type)? {
         
-        guard let sources = mediaEntry.sources else {return nil}
+        guard let sources = mediaEntry.sources else {
+            PKLog.error("no media sources in mediaEntry!")
+            return nil
+        }
         
         let defaultHandler = DefaultAssetHandler.self
         
@@ -52,6 +55,7 @@ class AssetBuilder {
             return (source, DRMSupport.widevineClassicHandler!)
         }
         
+        PKLog.error("no preferred media sources!")
         return nil
     }
 

--- a/Classes/Player/AssetLoaderDelegate.swift
+++ b/Classes/Player/AssetLoaderDelegate.swift
@@ -9,9 +9,7 @@ enum FairPlayError : Error {
     case malformedServerResponse
     case noCKCInResponse
     case malformedCKCInResponse
-    
 }
-
 
 class AssetLoaderDelegate: NSObject {
     

--- a/Classes/Player/PKEvent.swift
+++ b/Classes/Player/PKEvent.swift
@@ -66,7 +66,7 @@ extension PKEvent {
     }
     
     /// Associated error from error event, PKEvent Data Accessor
-    public var playerError: NSError? {
+    public var error: NSError? {
         return self.data?[EventDataKeys.Error] as? NSError
     }
     
@@ -95,7 +95,7 @@ extension PKEvent {
         return self.data?[AdEventDataKeys.WebOpener] as? NSObject
     }
     
-    /// Associated error from error event, PKEvent Data Accessor
+    /// Associated error from error event, PKEvent Ad Data Accessor
     public var adError: NSError? {
         return self.data?[AdEventDataKeys.Error] as? NSError
     }

--- a/Classes/Player/PKEvent.swift
+++ b/Classes/Player/PKEvent.swift
@@ -66,7 +66,7 @@ extension PKEvent {
     }
     
     /// Associated error from error event, PKEvent Data Accessor
-    public var error: NSError? {
+    public var playerError: NSError? {
         return self.data?[EventDataKeys.Error] as? NSError
     }
     
@@ -75,6 +75,7 @@ extension PKEvent {
         static let MediaTime = "mediaTime"
         static let TotalTime = "totalTime"
         static let WebOpener = "webOpener"
+        static let Error = "error"
     }
     
     // MARK: Ad Data Accessors
@@ -92,5 +93,10 @@ extension PKEvent {
     /// WebOpener, PKEvent Ad Data Accessor
     public var webOpener: NSObject? {
         return self.data?[AdEventDataKeys.WebOpener] as? NSObject
+    }
+    
+    /// Associated error from error event, PKEvent Data Accessor
+    public var adError: NSError? {
+        return self.data?[AdEventDataKeys.Error] as? NSError
     }
 }

--- a/Classes/Player/Player.swift
+++ b/Classes/Player/Player.swift
@@ -17,7 +17,10 @@ import AVKit
 @objc public protocol Player: NSObjectProtocol {
     
     @objc var delegate: PlayerDelegate? { get set }
-        
+    
+    /// The player's associated media entry.
+    weak var mediaEntry: MediaEntry? { get }
+    
     /**
      Get the player's layer component.
      */

--- a/Classes/Player/Player.swift
+++ b/Classes/Player/Player.swift
@@ -12,7 +12,6 @@ import AVKit
 
 @objc public protocol PlayerDelegate {
     func playerShouldPlayAd(_ player: Player) -> Bool
-    func player(_ player: Player, failedWith error: String)
 }
 
 @objc public protocol Player: NSObjectProtocol {
@@ -50,15 +49,18 @@ import AVKit
     func prepare(_ config: MediaConfig)
     
     /**
-     Convenience method for setting shouldPlayWhenReady to true.
+     send play action for the player.
      */
     func play()
     
     /**
-     Convenience method for setting shouldPlayWhenReady to false.
+     send pause action for the player.
      */
     func pause()
     
+    /**
+     send resume action for the player.
+     */
     func resume()
     
     func seek(to time: CMTime)

--- a/Classes/Player/PlayerController.swift
+++ b/Classes/Player/PlayerController.swift
@@ -16,71 +16,38 @@ class PlayerController: NSObject, Player {
     
     var delegate: PlayerDelegate?
     
-    private var currentPlayer: AVPlayerEngine?
+    private var currentPlayer: AVPlayerEngine
     private var assetBuilder: AssetBuilder?
     
     public var duration: Double {
-        get {
-            guard let currentPlayer = self.currentPlayer else {
-                PKLog.error("currentPlayer is empty")
-                return 0
-            }
-            
-            return (currentPlayer.duration)
-        }
+        return self.currentPlayer.duration
     }
     
     public var isPlaying: Bool {
-        get {
-            guard let currentPlayer = self.currentPlayer else {
-                PKLog.error("currentPlayer is empty")
-                return false
-            }
-            
-            return (currentPlayer.isPlaying)
-        }
+        return self.currentPlayer.isPlaying
     }
 
-    
     public var currentTime: TimeInterval {
-        get {
-            if let player = self.currentPlayer {
-                return player.currentPosition
-            }
-            
-            return 0
-        }
-        set {
-            if let player = self.currentPlayer {
-                player.currentPosition = currentTime
-            } else {
-                PKLog.error("currentPlayer is empty")
-            }
-        }
+        get { return self.currentPlayer.currentPosition }
+        set { self.currentPlayer.currentPosition = newValue }
     }
     
     public var currentAudioTrack: String? {
-        get {
-            return self.currentPlayer?.currentAudioTrack
-        }
+        return self.currentPlayer.currentAudioTrack
     }
     
     public var currentTextTrack: String? {
-        get {
-            return self.currentPlayer?.currentTextTrack
-        }
+        return self.currentPlayer.currentTextTrack
     }
     
     public var view: UIView! {
-        get {
-            return self.currentPlayer?.view
-        }
+        return self.currentPlayer.view
     }
     
     public override init() {
-        super.init()
         self.currentPlayer = AVPlayerEngine()
-        self.currentPlayer?.onEventBlock = { [weak self] event in
+        super.init()
+        self.currentPlayer.onEventBlock = { [weak self] event in
             PKLog.trace("postEvent:: \(event)")
             self?.onEventBlock?(event)
         }
@@ -88,42 +55,37 @@ class PlayerController: NSObject, Player {
     }
     
     func prepare(_ config: MediaConfig) {
-        if let player = self.currentPlayer {
-            player.startPosition = config.startTime
-            
-            if let mediaEntry: MediaEntry = config.mediaEntry  {
-                self.assetBuilder = AssetBuilder(mediaEntry: mediaEntry)
-                self.assetBuilder?.build(readyCallback: { (error: Error?, asset: AVAsset?) in
-                    if let avAsset: AVAsset = asset {
-                        self.currentPlayer?.asset = avAsset
-                    }
-                })
-            } else {
-                PKLog.warning("mediaEntry is empty")
-            }
+        currentPlayer.startPosition = config.startTime
+        if let mediaEntry: MediaEntry = config.mediaEntry  {
+            self.assetBuilder = AssetBuilder(mediaEntry: mediaEntry)
+            self.assetBuilder?.build(readyCallback: { (error: Error?, asset: AVAsset?) in
+                if let avAsset: AVAsset = asset {
+                    self.currentPlayer.asset = avAsset
+                }
+            })
         } else {
-            PKLog.error("player is empty")
+            PKLog.error("mediaEntry is empty")
         }
     }
     
     func play() {
         PKLog.trace("play::")
-        self.currentPlayer?.play()
+        self.currentPlayer.play()
     }
     
     func pause() {
         PKLog.trace("pause::")
-        self.currentPlayer?.pause()
+        self.currentPlayer.pause()
     }
     
     func resume() {
         PKLog.trace("resume::")
-        self.currentPlayer?.play()
+        self.currentPlayer.play()
     }
     
     func seek(to time: CMTime) {
         PKLog.trace("seek::\(time)")
-        self.currentPlayer?.currentPosition = CMTimeGetSeconds(time)
+        self.currentPlayer.currentPosition = CMTimeGetSeconds(time)
     }
     
     func prepareNext(_ config: MediaConfig) -> Bool {
@@ -136,11 +98,11 @@ class PlayerController: NSObject, Player {
     
     @available(iOS 9.0, *)
     func createPiPController(with delegate: AVPictureInPictureControllerDelegate) -> AVPictureInPictureController? {
-        return self.currentPlayer?.createPiPController(with: delegate)
+        return self.currentPlayer.createPiPController(with: delegate)
     }
     
     func destroy() {
-        self.currentPlayer?.destroy()
+        self.currentPlayer.destroy()
     }
     
     func addObserver(_ observer: AnyObject, events: [PKEvent.Type], block: @escaping (PKEvent) -> Void) {
@@ -152,6 +114,6 @@ class PlayerController: NSObject, Player {
     }
     
     public func selectTrack(trackId: String) {
-        self.currentPlayer?.selectTrack(trackId: trackId)
+        self.currentPlayer.selectTrack(trackId: trackId)
     }
 }

--- a/Classes/Player/PlayerController.swift
+++ b/Classes/Player/PlayerController.swift
@@ -19,6 +19,10 @@ class PlayerController: NSObject, Player {
     private var currentPlayer: AVPlayerEngine
     private var assetBuilder: AssetBuilder?
     
+    public var mediaEntry: MediaEntry? {
+        return assetBuilder?.mediaEntry
+    }
+    
     public var duration: Double {
         return self.currentPlayer.duration
     }
@@ -56,16 +60,12 @@ class PlayerController: NSObject, Player {
     
     func prepare(_ config: MediaConfig) {
         currentPlayer.startPosition = config.startTime
-        if let mediaEntry: MediaEntry = config.mediaEntry  {
-            self.assetBuilder = AssetBuilder(mediaEntry: mediaEntry)
-            self.assetBuilder?.build(readyCallback: { (error: Error?, asset: AVAsset?) in
-                if let avAsset: AVAsset = asset {
-                    self.currentPlayer.asset = avAsset
-                }
-            })
-        } else {
-            PKLog.error("mediaEntry is empty")
-        }
+        self.assetBuilder = AssetBuilder(mediaEntry: config.mediaEntry)
+        self.assetBuilder?.build(readyCallback: { (error: Error?, asset: AVAsset?) in
+            if let avAsset: AVAsset = asset {
+                self.currentPlayer.asset = avAsset
+            }
+        })
     }
     
     func play() {

--- a/Classes/Player/PlayerDecoratorBase.swift
+++ b/Classes/Player/PlayerDecoratorBase.swift
@@ -11,6 +11,7 @@ import AVFoundation
 import AVKit
 
 public class PlayerDecoratorBase: NSObject, Player {
+
     private var player: Player!
     
     public var delegate: PlayerDelegate? {
@@ -22,7 +23,11 @@ public class PlayerDecoratorBase: NSObject, Player {
         }
     }
 
-     public var currentTime: TimeInterval {
+    weak public var mediaEntry: MediaEntry? {
+        return self.player.mediaEntry
+    }
+    
+    public var currentTime: TimeInterval {
         get {
             return self.player.currentTime
         }
@@ -32,33 +37,23 @@ public class PlayerDecoratorBase: NSObject, Player {
     }
     
     public var duration: Double {
-        get {
-            return self.player.duration
-        }
+        return self.player.duration
     }
     
     public var currentAudioTrack: String? {
-        get {
-            return self.player.currentAudioTrack
-        }
+        return self.player.currentAudioTrack
     }
 
     public var currentTextTrack: String? {
-        get {
-            return self.player.currentTextTrack
-        }
+        return self.player.currentTextTrack
     }
     
     public var isPlaying: Bool {
-        get {
-            return self.player.isPlaying
-        }
+        return self.player.isPlaying
     }
     
     public var view: UIView! {
-        get {
-            return self.player.view
-        }
+        return self.player.view
     }
     
     public func prepare(_ config: MediaConfig) {

--- a/Classes/Player/PlayerLoader.swift
+++ b/Classes/Player/PlayerLoader.swift
@@ -48,8 +48,8 @@ class PlayerLoader: PlayerDecoratorBase {
                     
                     loadedPlugins[pluginName] = LoadedPlugin(plugin: pluginObject, decorator: decorator)
                 } catch let e {
-                    if case let error = PKPluginError.failedToCreatePlugin {
-                        self.messageBus.post(PlayerEvent.Error(nsError: error.asNSError))
+                    if case PKPluginError.failedToCreatePlugin = e {
+                        self.messageBus.post(PlayerEvent.Error(nsError: PKPluginError.failedToCreatePlugin.asNSError))
                     }
                 }
             }

--- a/Classes/Player/PlayerLoader.swift
+++ b/Classes/Player/PlayerLoader.swift
@@ -35,23 +35,17 @@ class PlayerLoader: PlayerDecoratorBase {
         if let pluginConfigs = pluginConfig?.config {
             for pluginName in pluginConfigs.keys {
                 let pluginConfig = pluginConfigs[pluginName]
-                do {
-                    let pluginObject = try PlayKitManager.shared.createPlugin(name: pluginName, player: player, pluginConfig: pluginConfig, messageBus: self.messageBus)
-                    
-                    var decorator: PlayerDecoratorBase? = nil
-                    
-                    if let d = (pluginObject as? PlayerDecoratorProvider)?.getPlayerDecorator() {
-                        d.setPlayer(player)
-                        decorator = d
-                        player = d
-                    }
-                    
-                    loadedPlugins[pluginName] = LoadedPlugin(plugin: pluginObject, decorator: decorator)
-                } catch let e {
-                    if case let error = PKPluginError.failedToCreatePlugin {
-                        self.messageBus.post(PlayerEvent.Error(nsError: error.asNSError))
-                    }
+                let pluginObject = try PlayKitManager.shared.createPlugin(name: pluginName, player: player, pluginConfig: pluginConfig, messageBus: self.messageBus)
+                
+                var decorator: PlayerDecoratorBase? = nil
+                
+                if let d = (pluginObject as? PlayerDecoratorProvider)?.getPlayerDecorator() {
+                    d.setPlayer(player)
+                    decorator = d
+                    player = d
                 }
+                
+                loadedPlugins[pluginName] = LoadedPlugin(plugin: pluginObject, decorator: decorator)
             }
         }
         setPlayer(player)

--- a/Classes/Player/PlayerLoader.swift
+++ b/Classes/Player/PlayerLoader.swift
@@ -37,8 +37,7 @@ class PlayerLoader: PlayerDecoratorBase {
                 let pluginConfig = pluginConfigs[pluginName]
                 do {
                     let pluginObject = try PlayKitManager.shared.createPlugin(name: pluginName, player: player, pluginConfig: pluginConfig, messageBus: self.messageBus)
-                    // TODO::
-                    // send message bus
+                    
                     var decorator: PlayerDecoratorBase? = nil
                     
                     if let d = (pluginObject as? PlayerDecoratorProvider)?.getPlayerDecorator() {
@@ -59,12 +58,12 @@ class PlayerLoader: PlayerDecoratorBase {
     }
     
     override func prepare(_ config: MediaConfig) {
+        super.prepare(config)
         // update all loaded plugins with media config
         for (pluginName, loadedPlugin) in loadedPlugins {
             PKLog.trace("Preparing plugin", pluginName)
             loadedPlugin.plugin.onLoad(mediaConfig: config)
         }
-        super.prepare(config)
     }
     
     func destroyPlayer() {

--- a/Classes/Player/PlayerLoader.swift
+++ b/Classes/Player/PlayerLoader.swift
@@ -35,17 +35,23 @@ class PlayerLoader: PlayerDecoratorBase {
         if let pluginConfigs = pluginConfig?.config {
             for pluginName in pluginConfigs.keys {
                 let pluginConfig = pluginConfigs[pluginName]
-                let pluginObject = try PlayKitManager.shared.createPlugin(name: pluginName, player: player, pluginConfig: pluginConfig, messageBus: self.messageBus)
-                
-                var decorator: PlayerDecoratorBase? = nil
-                
-                if let d = (pluginObject as? PlayerDecoratorProvider)?.getPlayerDecorator() {
-                    d.setPlayer(player)
-                    decorator = d
-                    player = d
+                do {
+                    let pluginObject = try PlayKitManager.shared.createPlugin(name: pluginName, player: player, pluginConfig: pluginConfig, messageBus: self.messageBus)
+                    
+                    var decorator: PlayerDecoratorBase? = nil
+                    
+                    if let d = (pluginObject as? PlayerDecoratorProvider)?.getPlayerDecorator() {
+                        d.setPlayer(player)
+                        decorator = d
+                        player = d
+                    }
+                    
+                    loadedPlugins[pluginName] = LoadedPlugin(plugin: pluginObject, decorator: decorator)
+                } catch let e {
+                    if case let error = PKPluginError.failedToCreatePlugin {
+                        self.messageBus.post(PlayerEvent.Error(nsError: error.asNSError))
+                    }
                 }
-                
-                loadedPlugins[pluginName] = LoadedPlugin(plugin: pluginObject, decorator: decorator)
             }
         }
         setPlayer(player)

--- a/Classes/Player/PlayerLoader.swift
+++ b/Classes/Player/PlayerLoader.swift
@@ -30,15 +30,13 @@ class PlayerLoader: PlayerDecoratorBase {
             self.messageBus.post(event)
         }
         
-        // TODO::
-        // add event listener on player controller
-        
         var player: Player = playerController
         
         if let pluginConfigs = pluginConfig?.config {
             for pluginName in pluginConfigs.keys {
                 let pluginConfig = pluginConfigs[pluginName]
-                if let pluginObject = PlayKitManager.shared.createPlugin(name: pluginName, player: player, pluginConfig: pluginConfig, messageBus: self.messageBus) {
+                do {
+                    let pluginObject = try PlayKitManager.shared.createPlugin(name: pluginName, player: player, pluginConfig: pluginConfig, messageBus: self.messageBus)
                     // TODO::
                     // send message bus
                     var decorator: PlayerDecoratorBase? = nil
@@ -50,6 +48,10 @@ class PlayerLoader: PlayerDecoratorBase {
                     }
                     
                     loadedPlugins[pluginName] = LoadedPlugin(plugin: pluginObject, decorator: decorator)
+                } catch let e {
+                    if case let error = PKPluginError.failedToCreatePlugin {
+                        self.messageBus.post(PlayerEvent.Error(nsError: error.asNSError))
+                    }
                 }
             }
         }

--- a/Classes/PlayerEvent.swift
+++ b/Classes/PlayerEvent.swift
@@ -27,8 +27,6 @@ public class PlayerEvent: PKEvent {
     public static let ended: PlayerEvent.Type = Ended.self
     /// The media's metadata has finished loading; all attributes now contain as much useful information as they're going to.
     public static let loadedMetadata: PlayerEvent.Type = LoadedMetadata.self
-    /// Sent when an error occurs.
-    public static let error: PlayerEvent.Type = Error.self
     /// Sent when playback of the media starts after having been paused; that is, when playback is resumed after a prior pause event.
     public static let play: PlayerEvent.Type = Play.self
     /// Sent when playback is paused.
@@ -45,6 +43,11 @@ public class PlayerEvent: PKEvent {
     public static let playbackParamsUpdated: PlayerEvent.Type = PlaybackParamsUpdated.self
     /// Sent when player state is changed.
     public static let stateChanged: PlayerEvent.Type = StateChanged.self
+    
+    /// Sent when an error occurs.
+    public static let error: PlayerEvent.Type = Error.self
+    /// Sent when an plugin error occurs.
+    public static let pluginError: PlayerEvent.Type = PluginError.self
     
     // MARK: - Player Basic Events
 
@@ -64,8 +67,14 @@ public class PlayerEvent: PKEvent {
     class Seeked : PlayerEvent {}
     
     class Error: PlayerEvent {
-        convenience init(error: NSError) {
-            self.init([EventDataKeys.Error : error])
+        convenience init(nsError: NSError) {
+            self.init([EventDataKeys.Error : nsError])
+        }
+    }
+    
+    class PluginError: PlayerEvent {
+        convenience init(nsError: NSError) {
+            self.init([EventDataKeys.Error : nsError])
         }
     }
     
@@ -127,6 +136,8 @@ public class AdEvent: PKEvent {
     public static let adWebOpenerDidOpenInAppBrowser: AdEvent.Type = AdWebOpenerDidOpenInAppBrowser.self
     public static let adWebOpenerWillCloseInAppBrowser: AdEvent.Type = AdWebOpenerWillCloseInAppBrowser.self
     public static let adWebOpenerDidCloseInAppBrowser: AdEvent.Type = AdWebOpenerDidCloseInAppBrowser.self
+    /// Sent when an error occurs.
+    public static let error: AdEvent.Type = Error.self
     
     class AdBreakReady : AdEvent {}
     class AdBreakEnded : AdEvent {}
@@ -146,6 +157,12 @@ public class AdEvent: PKEvent {
     class AdStreamLoaded : AdEvent {}
     class AdTapped : AdEvent {}
     class AdThirdQuartile : AdEvent {}
+    
+    class Error: AdEvent {
+        convenience init(nsError: NSError) {
+            self.init([AdEventDataKeys.Error : nsError])
+        }
+    }
     
     class AdDidProgressToTime : AdEvent {
         convenience init(mediaTime: TimeInterval, totalTime: TimeInterval) {

--- a/Classes/Plugins/Ads/AdsEnabledPlayerController.swift
+++ b/Classes/Plugins/Ads/AdsEnabledPlayerController.swift
@@ -80,13 +80,11 @@ class AdsEnabledPlayerController : PlayerDecoratorBase, AdsPluginDelegate, AdsPl
         if self.isPlayEnabled {
             super.play()
         }
-        self.delegate?.player(self, failedWith: error)
     }
     
     func adsPlugin(_ adsPlugin: AdsPlugin, managerFailedWith error: String) {
         super.play()
         self.isAdPlayback = false
-        self.delegate?.player(self, failedWith: error)
     }
     
     func adsPlugin(_ adsPlugin: AdsPlugin, didReceive event: PKEvent) {

--- a/Classes/Plugins/BasePlugin.swift
+++ b/Classes/Plugins/BasePlugin.swift
@@ -9,7 +9,7 @@
 import Foundation
 
 /// class `BasePlugin` is a base plugin object used for plugin subclasses
-public class BasePlugin: NSObject, PKPlugin {
+@objc public class BasePlugin: NSObject, PKPlugin {
     
     /// abstract implementation subclasses will have names
     public class var pluginName: String {

--- a/Classes/Plugins/BasePlugin.swift
+++ b/Classes/Plugins/BasePlugin.swift
@@ -1,0 +1,38 @@
+//
+//  BasePlugin.swift
+//  Pods
+//
+//  Created by Gal Orlanczyk on 21/02/2017.
+//
+//
+
+import Foundation
+
+/// class `BasePlugin` is a base plugin object used for plugin subclasses
+public class BasePlugin: NSObject, PKPlugin {
+    
+    /// abstract implementation subclasses will have names
+    public class var pluginName: String {
+        fatalError("abstract property should be overriden in subclass")
+    }
+
+    public unowned var player: Player
+    
+    public required init(player: Player, pluginConfig: Any?, messageBus: MessageBus) {
+        PKLog.info("initializing plugin \(type(of:self))")
+        self.player = player
+    }
+    
+    public func onLoad(mediaConfig: MediaConfig) {
+        PKLog.info("plugin \(type(of:self)) onLoad with media config: \(mediaConfig)")
+    }
+    
+    public func onUpdateMedia(mediaConfig: MediaConfig) {
+        PKLog.info("plugin \(type(of:self)) onUpdateMedia with media config: \(mediaConfig)")
+    }
+    
+    public func destroy() {
+        PKLog.info("destroying plugin \(type(of:self))")
+    }
+}
+

--- a/Classes/Plugins/PKPlugin.swift
+++ b/Classes/Plugins/PKPlugin.swift
@@ -24,9 +24,10 @@ import AVFoundation
 public protocol PKPlugin: Plugin {
     /// The plugin name.
     static var pluginName: String { get }
-    /// The associated media entry.
-    weak var mediaEntry: MediaEntry? { get set }
 
+    /// The player associated with the plugin
+    unowned var player: Player { get set }
+    
     init(player: Player, pluginConfig: Any?, messageBus: MessageBus)
     
     /// On first load. used for doing initialization for the first time with the media config.

--- a/Classes/Plugins/PKPlugin.swift
+++ b/Classes/Plugins/PKPlugin.swift
@@ -37,13 +37,17 @@ public protocol PKPlugin: Plugin {
     func destroy()
 }
 
+/************************************************************/
+// MARK: - PKPluginError
+/************************************************************/
+
 /// `PKPluginError` represents plugins errors.
 enum PKPluginError: PKError {
     
     case failedToCreatePlugin
     case missingPluginConfig(pluginName: String)
     
-    static let Domain = PKErrorDomain.Plugin
+    static let Domain = "com.kaltura.playkit.error.plugins"
     
     var code: Int {
         switch self {
@@ -62,7 +66,12 @@ enum PKPluginError: PKError {
     var userInfo: [String: Any] {
         switch self {
         case .failedToCreatePlugin: return [:]
-        case .missingPluginConfig(let pluginName): return [PluginNameKey : pluginName]
+        case .missingPluginConfig(let pluginName): return [PKErrorKeys.PluginNameKey : pluginName]
         }
     }
+}
+
+// general plugin error userInfo keys.
+extension PKErrorKeys {
+    static let PluginNameKey = "pluginName"
 }

--- a/Classes/Plugins/PKPlugin.swift
+++ b/Classes/Plugins/PKPlugin.swift
@@ -9,19 +9,8 @@
 import UIKit
 import AVFoundation
 
-/**
- Used as a workaround for Apple bug with swift interoperability.
- 
- There is an issue with initializing an object based on a protocol.Type with @objc attribute.
- Therefore we use a wrapper protocol for PKPlugin with @objc and then casting to a PKPlugin without the @objc attribute.
- 
- - important:
- **should not be used! use PKPlugin to add a plugin**
- */
-@objc public protocol Plugin {}
-
 /// The `PKPlugin` protocol defines all the properties and methods required to define a plugin object.
-public protocol PKPlugin: Plugin {
+public protocol PKPlugin {
     /// The plugin name.
     static var pluginName: String { get }
 
@@ -34,44 +23,7 @@ public protocol PKPlugin: Plugin {
     func onLoad(mediaConfig: MediaConfig)
     /// On update media. used to update the plugin with new media config when available
     func onUpdateMedia(mediaConfig: MediaConfig)
+    
     func destroy()
 }
 
-/************************************************************/
-// MARK: - PKPluginError
-/************************************************************/
-
-/// `PKPluginError` represents plugins errors.
-enum PKPluginError: PKError {
-    
-    case failedToCreatePlugin
-    case missingPluginConfig(pluginName: String)
-    
-    static let Domain = "com.kaltura.playkit.error.plugins"
-    
-    var code: Int {
-        switch self {
-        case .failedToCreatePlugin: return 2000
-        case .missingPluginConfig: return 2001
-        }
-    }
-    
-    var errorDescription: String {
-        switch self {
-        case .failedToCreatePlugin: return "failed to create plugin, doesn't exist in registry"
-        case .missingPluginConfig(let pluginName): return "Missing plugin config for plugin: \(pluginName)"
-        }
-    }
-    
-    var userInfo: [String: Any] {
-        switch self {
-        case .failedToCreatePlugin: return [:]
-        case .missingPluginConfig(let pluginName): return [PKErrorKeys.PluginNameKey : pluginName]
-        }
-    }
-}
-
-// general plugin error userInfo keys.
-extension PKErrorKeys {
-    static let PluginNameKey = "pluginName"
-}

--- a/Classes/Plugins/PKPlugin.swift
+++ b/Classes/Plugins/PKPlugin.swift
@@ -36,3 +36,32 @@ public protocol PKPlugin: Plugin {
     func destroy()
 }
 
+/// `PKPluginError` represents plugins errors.
+enum PKPluginError: PKError {
+    
+    case failedToCreatePlugin
+    case missingPluginConfig(pluginName: String)
+    
+    static let Domain = PKErrorDomain.Plugin
+    
+    var code: Int {
+        switch self {
+        case .failedToCreatePlugin: return 2000
+        case .missingPluginConfig: return 2001
+        }
+    }
+    
+    var errorDescription: String {
+        switch self {
+        case .failedToCreatePlugin: return "failed to create plugin, doesn't exist in registry"
+        case .missingPluginConfig(let pluginName): return "Missing plugin config for plugin: \(pluginName)"
+        }
+    }
+    
+    var userInfo: [String: Any] {
+        switch self {
+        case .failedToCreatePlugin: return [:]
+        case .missingPluginConfig(let pluginName): return [PluginNameKey : pluginName]
+        }
+    }
+}

--- a/Classes/Providers/OTT/OTTMediaProvider.swift
+++ b/Classes/Providers/OTT/OTTMediaProvider.swift
@@ -11,14 +11,13 @@ import SwiftyJSON
 
 public class OTTMediaProvider: MediaEntryProvider {
     
-    
     var sessionProvider: SessionProvider?
     var mediaId: String?
     var type: AssetType?
     var formats: [String]?
     var executor: RequestExecutor?
     
-    public enum Err: Error {
+    public enum OTTMediaProviderError: Error {
         case invalidInputParams
         case invalidKS
         case fileIsEmptyOrNotFound
@@ -27,7 +26,6 @@ public class OTTMediaProvider: MediaEntryProvider {
         case currentlyProcessingOtherRequest
         case unableToParseObject
     }
-    
     
     public init(){
         
@@ -81,7 +79,7 @@ public class OTTMediaProvider: MediaEntryProvider {
             let mediaId = self.mediaId,
             let type = self.type
             else {
-                callback(Result(data: nil, error: Err.invalidInputParams))
+                callback(Result(data: nil, error: OTTMediaProviderError.invalidInputParams))
                 return
         }
         
@@ -108,7 +106,7 @@ public class OTTMediaProvider: MediaEntryProvider {
         loader.sessionProvider.loadKS { (r:Result<String>) in
             
             guard let ks = r.data else {
-                callback(Result(data: nil, error: Err.invalidKS))
+                callback(Result(data: nil, error: OTTMediaProviderError.invalidKS))
                 return
             }
             
@@ -117,7 +115,7 @@ public class OTTMediaProvider: MediaEntryProvider {
                 .set(completion: { (r:Response) in
                     
                     guard let data = r.data else {
-                        callback(Result(data: nil, error: Err.mediaNotFound))
+                        callback(Result(data: nil, error: OTTMediaProviderError.mediaNotFound))
                         return
                     }
                     
@@ -152,7 +150,7 @@ public class OTTMediaProvider: MediaEntryProvider {
                         
                         callback(Result(data: mediaEntry, error: nil))
                     }else{
-                        callback(Result(data: nil, error: Err.mediaNotFound))
+                        callback(Result(data: nil, error: OTTMediaProviderError.mediaNotFound))
                     }
                     
                 })

--- a/Classes/Providers/OTT/Parsers/OTTMultiResponseParser.swift
+++ b/Classes/Providers/OTT/Parsers/OTTMultiResponseParser.swift
@@ -11,8 +11,7 @@ import SwiftyJSON
 
 class OTTMultiResponseParser: NSObject {
     
-    
-    enum error: Error {
+    enum OTTMultiResponseParserError: Error {
         case typeNotFound
         case emptyResponse
         case notMultiResponse
@@ -21,7 +20,7 @@ class OTTMultiResponseParser: NSObject {
     static func parse(data:Any) throws -> [OTTBaseObject] {
         
         let jsonResponse = JSON(data)
-        if let resultArrayJSON = jsonResponse["result"].array{
+        if let resultArrayJSON = jsonResponse["result"].array {
             
             var resultArray: [OTTBaseObject] = [OTTBaseObject]()
             for jsonObject: JSON in resultArrayJSON{
@@ -29,8 +28,8 @@ class OTTMultiResponseParser: NSObject {
                 let objectType: OTTBaseObject.Type? = OTTObjectMapper.classByJsonObject(json: jsonObject.dictionaryObject)
                 if let type = objectType{
                      object = type.init(json: jsonObject.object)
-                }else{
-                    throw error.typeNotFound
+                } else {
+                    throw OTTMultiResponseParserError.typeNotFound
                 }
                 
                 if let obj = object{
@@ -39,7 +38,7 @@ class OTTMultiResponseParser: NSObject {
             }
             
             return resultArray
-        }else{
+        } else {
             return [OTTBaseObject]()
         }
     }

--- a/Classes/Providers/OTT/Parsers/OTTObjectMapper.swift
+++ b/Classes/Providers/OTT/Parsers/OTTObjectMapper.swift
@@ -36,7 +36,7 @@ class OTTObjectMapper: NSObject {
             default:
                 return nil
             }
-        }else{
+        } else {
             if jsonObject[errorKey].dictionary != nil {
                 return OTTError.self
             }else{

--- a/Classes/Providers/OTT/Parsers/OTTResponseParser.swift
+++ b/Classes/Providers/OTT/Parsers/OTTResponseParser.swift
@@ -11,10 +11,9 @@ import SwiftyJSON
 
 class OTTResponseParser: ResponseParser {
     
-    enum error: Error {
+    enum OTTResponseParserError: Error {
         case typeNotFound
         case invalidJsonObject
-        
     }
     
     static func parse(data:Any) throws -> OTTBaseObject {
@@ -26,10 +25,10 @@ class OTTResponseParser: ResponseParser {
             if let object = type.init(json: resultObjectJSON) {
                 return object
             }else{
-              throw error.invalidJsonObject
+              throw OTTResponseParserError.invalidJsonObject
             }
         }else{
-            throw error.typeNotFound
+            throw OTTResponseParserError.typeNotFound
         }
     }
 }

--- a/Classes/Providers/OVP/Model/OVPBaseObject.swift
+++ b/Classes/Providers/OVP/Model/OVPBaseObject.swift
@@ -10,5 +10,5 @@ import UIKit
 
 protocol OVPBaseObject{
     
-    init?(json:Any)
+    init?(json: Any)
 }

--- a/Classes/Providers/OVP/Parsers/OVPResponseParser.swift
+++ b/Classes/Providers/OVP/Parsers/OVPResponseParser.swift
@@ -14,7 +14,6 @@ class OVPResponseParser: ResponseParser {
     enum error: Error {
         case typeNotFound
         case invalidJsonObject
-        
     }
     
     static func parse(data:Any) throws -> OVPBaseObject {
@@ -25,10 +24,10 @@ class OVPResponseParser: ResponseParser {
         if let type = objectType{
             if let object = type.init(json: resultObjectJSON) {
                 return object
-            }else{
+            } else {
                 throw error.invalidJsonObject
             }
-        }else{
+        } else {
             throw error.typeNotFound
         }
     }
@@ -43,19 +42,16 @@ class OVPResponseParser: ResponseParser {
             if let object = type.init(json: resultObjectJSON) {
                 if let result = object as? T {
                     return result
-                }else{
+                } else {
                     return nil
                 }
-            }else{
+            } else {
                 throw error.invalidJsonObject
             }
-        }else{
+        } else {
             throw error.typeNotFound
         }
-
     }
-    
-    
 }
 
 

--- a/Classes/Providers/OVP/Session/OVPSessionManager.swift
+++ b/Classes/Providers/OVP/Session/OVPSessionManager.swift
@@ -10,9 +10,7 @@ import UIKit
 
 public class OVPSessionManager: SessionProvider {
     
-    
     public enum SessionManagerError: Error{
-        
         case failedToGetKS
         case failedToGetLoginResponse
         case failedToRefreshKS
@@ -21,7 +19,6 @@ public class OVPSessionManager: SessionProvider {
         case noRefreshTokenOrTokenToRefresh
         case failedToParseResponse
         case ksExpired
-        
     }
     
     public var serverURL: String
@@ -73,7 +70,7 @@ public class OVPSessionManager: SessionProvider {
                                     self.ensureKSAfterRefresh(e: e, completion: completion)
                 })
             }
-            else{
+            else {
                 
                 self.startAnonymousSession(completion: { (e:Error?) in
                     self.ensureKSAfterRefresh(e: e, completion: completion)
@@ -89,20 +86,17 @@ public class OVPSessionManager: SessionProvider {
     func ensureKSAfterRefresh(e:Error?,completion: @escaping (_ result :Result<String>) -> Void) -> Void {
         if let ks = self.ks {
             completion(Result(data: ks))
-        }else if let error = e {
+        } else if let error = e {
             completion(Result(error: error))
-        }else{
+        } else {
             completion(Result(error: SessionManagerError.ksExpired))
         }
     }
     
     
-    public func startAnonymousSession(completion:@escaping (_ error:Error?)->Void) -> Void {
+    public func startAnonymousSession(completion:@escaping (_ error: Error?) -> Void) -> Void {
         
-        let loginRequestBuilder = OVPSessionService.startWidgetSession(baseURL: self.fullServerPath,
-                                                                       partnerId: self.partnerId)?
-        
-        
+        let loginRequestBuilder = OVPSessionService.startWidgetSession(baseURL: self.fullServerPath, partnerId: self.partnerId)?
             .setOVPBasicParams()
             .set(completion: { (r:Response) in
                 
@@ -126,19 +120,16 @@ public class OVPSessionManager: SessionProvider {
                 }else{
                     completion(SessionManagerError.failedToGetLoginResponse)
                 }
-                
-                
             })
-            
-            
-            if let request = loginRequestBuilder?.build() {
-                self.executor.send(request: request)
-            }
+        
+        if let request = loginRequestBuilder?.build() {
+            self.executor.send(request: request)
+        }
     }
 
 
     
-    public func startSession(username:String,password:String,completion:@escaping (_ error:Error?)->Void) -> Void {
+    public func startSession(username: String, password: String, completion: @escaping (_ error: Error?) -> Void) -> Void {
         
         self.username = username
         self.password = password
@@ -158,8 +149,7 @@ public class OVPSessionManager: SessionProvider {
                 
                 if let data = r.data
                 {
-                    do{
-                        
+                    do {
                         guard   let arrayResult = data as? [Any],
                                 arrayResult.count == 2
                         else {
@@ -171,15 +161,13 @@ public class OVPSessionManager: SessionProvider {
                         self.ks = arrayResult[0] as? String
                         self.tokenExpiration = sessionInfo?.expiry
                         completion(nil)
-                    }catch{
+                    } catch {
                         completion(error)
                     }
                     
-                }else{
+                } else {
                     completion(SessionManagerError.failedToGetLoginResponse)
                 }
-                
-                
             })
             
             

--- a/Plugins/AnalyticsCommon/BaseAnalyticsPlugin.swift
+++ b/Plugins/AnalyticsCommon/BaseAnalyticsPlugin.swift
@@ -8,13 +8,17 @@
 
 import Foundation
 
+/************************************************************/
+// MARK: - AnalyticsPluginError
+/************************************************************/
+
 /// `AnalyticsError` represents analytics plugins (kaltura stats, kaltura live stats, phoenix and tvpapi) common errors.
-enum AnalyticsError: PKError {
+enum AnalyticsPluginError: PKError {
     
     case missingMediaEntry
     case missingInitObject
     
-    static let Domain = PKErrorDomain.AnalyticsPlugin
+    static let Domain = "com.kaltura.playkit.error.analyticsPlugin"
     
     var code: Int {
         switch self {
@@ -34,6 +38,14 @@ enum AnalyticsError: PKError {
         return [:]
     }
 }
+
+extension PKErrorDomain {
+    public static let AnalyticsPlugin = AnalyticsPluginError.Domain
+}
+
+/************************************************************/
+// MARK: - BaseAnalyticsPlugin
+/************************************************************/
 
 /// class `BaseAnalyticsPlugin` is a base plugin object used for analytics plugin subclasses
 public class BaseAnalyticsPlugin: BasePlugin, AnalyticsPluginProtocol {

--- a/Plugins/AnalyticsCommon/BaseAnalyticsPlugin.swift
+++ b/Plugins/AnalyticsCommon/BaseAnalyticsPlugin.swift
@@ -8,6 +8,33 @@
 
 import Foundation
 
+/// `AnalyticsError` represents analytics plugins (kaltura stats, kaltura live stats, phoenix and tvpapi) common errors.
+enum AnalyticsError: PKError {
+    
+    case missingMediaEntry
+    case missingInitObject
+    
+    static let Domain = PKErrorDomain.AnalyticsPlugin
+    
+    var code: Int {
+        switch self {
+        case .missingMediaEntry: return 3000
+        case .missingInitObject: return 3001
+        }
+    }
+    
+    var errorDescription: String {
+        switch self {
+        case .missingMediaEntry: return "failed to send analytics event, mediaEntry is nil"
+        case .missingInitObject: return "failed to send analytics event, missing initObj"
+        }
+    }
+    
+    var userInfo: [String: Any] {
+        return [:]
+    }
+}
+
 /// class `BaseAnalyticsPlugin` is a base plugin object used for analytics plugin subclasses
 public class BaseAnalyticsPlugin: AnalyticsPluginProtocol {
     
@@ -34,7 +61,7 @@ public class BaseAnalyticsPlugin: AnalyticsPluginProtocol {
         if let aConfig = pluginConfig as? AnalyticsConfig {
             self.config = aConfig
         } else {
-            PKLog.warning("There is no Analytics Config.")
+            PKLog.error("There is no Analytics Config.")
         }
         self.registerEvents()
     }

--- a/Plugins/AnalyticsCommon/BaseAnalyticsPlugin.swift
+++ b/Plugins/AnalyticsCommon/BaseAnalyticsPlugin.swift
@@ -36,17 +36,9 @@ enum AnalyticsError: PKError {
 }
 
 /// class `BaseAnalyticsPlugin` is a base plugin object used for analytics plugin subclasses
-public class BaseAnalyticsPlugin: AnalyticsPluginProtocol {
+public class BaseAnalyticsPlugin: BasePlugin, AnalyticsPluginProtocol {
     
-    /// abstract implementation subclasses will have names
-    public class var pluginName: String {
-        fatalError("abstract property should be overriden in subclass")
-    }
-    
-    unowned var player: Player
     unowned var messageBus: MessageBus
-    public weak var mediaEntry: MediaEntry?
-    
     var config: AnalyticsConfig?
     var isFirstPlay: Bool = true
     
@@ -54,10 +46,9 @@ public class BaseAnalyticsPlugin: AnalyticsPluginProtocol {
     // MARK: - PKPlugin
     /************************************************************/
     
-    public required init(player: Player, pluginConfig: Any?, messageBus: MessageBus) {
-        PKLog.info("initializing plugin \(type(of:self))")
-        self.player = player
+    public override required init(player: Player, pluginConfig: Any?, messageBus: MessageBus) {
         self.messageBus = messageBus
+        super.init(player: player, pluginConfig: pluginConfig, messageBus: messageBus)
         if let aConfig = pluginConfig as? AnalyticsConfig {
             self.config = aConfig
         } else {
@@ -66,18 +57,8 @@ public class BaseAnalyticsPlugin: AnalyticsPluginProtocol {
         self.registerEvents()
     }
     
-    public func onLoad(mediaConfig: MediaConfig) {
-        PKLog.info("plugin \(type(of:self)) onLoad with media config: \(mediaConfig)")
-        self.mediaEntry = mediaConfig.mediaEntry
-    }
-    
-    public func onUpdateMedia(mediaConfig: MediaConfig) {
-        PKLog.info("plugin \(type(of:self)) onUpdateMedia with media config: \(mediaConfig)")
-        self.mediaEntry = mediaConfig.mediaEntry
-    }
-    
-    public func destroy() {
-        PKLog.info("destroying plugin \(type(of:self))")
+    public override func destroy() {
+        super.destroy()
         self.messageBus.removeObserver(self, events: playerEventsToRegister)
     }
 

--- a/Plugins/AnalyticsCommon/BaseAnalyticsPlugin.swift
+++ b/Plugins/AnalyticsCommon/BaseAnalyticsPlugin.swift
@@ -52,7 +52,9 @@ public class BaseAnalyticsPlugin: BasePlugin, AnalyticsPluginProtocol {
         if let aConfig = pluginConfig as? AnalyticsConfig {
             self.config = aConfig
         } else {
-            PKLog.error("There is no Analytics Config.")
+            PKLog.error("There is no Analytics Config!")
+            let error = PKPluginError.missingPluginConfig(pluginName: type(of: self).pluginName).asNSError
+            self.messageBus.post(PlayerEvent.PluginError(nsError: error))
         }
         self.registerEvents()
     }

--- a/Plugins/IMA/IMAPlugin.swift
+++ b/Plugins/IMA/IMAPlugin.swift
@@ -8,12 +8,16 @@
 
 import GoogleInteractiveMediaAds
 
+/************************************************************/
+// MARK: - IMAPluginError
+/************************************************************/
+
 /// `IMAPluginError` used to wrap an `IMAAdError` and provide converation to `NSError`
 struct IMAPluginError: PKError {
     
     var adError: IMAAdError
     
-    static let Domain = PKErrorDomain.IMA
+    static let Domain = "com.kaltura.playkit.error.ima"
     
     var code: Int {
         return adError.code.rawValue
@@ -25,17 +29,23 @@ struct IMAPluginError: PKError {
     
     var userInfo: [String: Any] {
         return [
-            ErrorTypeKey : adError.type.rawValue
+            PKErrorKeys.ErrorTypeKey : adError.type.rawValue
         ]
     }
 }
 
 // IMA plugin error userInfo keys.
-extension IMAPluginError {
-    var ErrorTypeKey: String {
-        return "errorType"
-    }
+extension PKErrorKeys {
+    static let ErrorTypeKey = "errorType"
 }
+
+extension PKErrorDomain {
+    public static let IMA = IMAPluginError.Domain
+}
+
+/************************************************************/
+// MARK: - IMAPlugin
+/************************************************************/
 
 public class IMAPlugin: BasePlugin, PlayerDecoratorProvider, AdsPlugin, IMAAdsLoaderDelegate, IMAAdsManagerDelegate, IMAWebOpenerDelegate, IMAContentPlayhead {
 

--- a/Plugins/IMA/IMAPlugin.swift
+++ b/Plugins/IMA/IMAPlugin.swift
@@ -37,11 +37,8 @@ extension IMAPluginError {
     }
 }
 
-public class IMAPlugin: NSObject, PlayerDecoratorProvider, AdsPlugin, IMAAdsLoaderDelegate, IMAAdsManagerDelegate, IMAWebOpenerDelegate, IMAContentPlayhead {
-    
-    public weak var mediaEntry: MediaEntry?
+public class IMAPlugin: BasePlugin, PlayerDecoratorProvider, AdsPlugin, IMAAdsLoaderDelegate, IMAAdsManagerDelegate, IMAWebOpenerDelegate, IMAContentPlayhead {
 
-    private unowned var player: Player
     private unowned var messageBus: MessageBus
     
     weak var dataSource: AdsPluginDataSource? {
@@ -86,11 +83,9 @@ public class IMAPlugin: NSObject, PlayerDecoratorProvider, AdsPlugin, IMAAdsLoad
     // MARK: - PKPlugin
     /************************************************************/
     
-    public required init(player: Player, pluginConfig: Any?, messageBus: MessageBus) {
-        PKLog.info("intializing plugin \(type(of:self))")
+    public override required init(player: Player, pluginConfig: Any?, messageBus: MessageBus) {
         self.messageBus = messageBus
-        self.player = player
-        super.init()
+        super.init(player: player, pluginConfig: pluginConfig, messageBus: messageBus)
         if let adsConfig = pluginConfig as? AdsConfig {
             self.config = adsConfig
             if IMAPlugin.loader == nil {
@@ -117,20 +112,10 @@ public class IMAPlugin: NSObject, PlayerDecoratorProvider, AdsPlugin, IMAAdsLoad
         self.timer = Timer.scheduledTimer(timeInterval: 0.2, target: self, selector: #selector(IMAPlugin.update), userInfo: nil, repeats: true)
     }
     
-    public func onLoad(mediaConfig: MediaConfig) {
-        PKLog.debug("plugin \(type(of:self)) onLoad with media config: \(mediaConfig)")
-        self.mediaEntry = mediaConfig.mediaEntry
-    }
+    public override class var pluginName: String { return "IMAPlugin" }
     
-    public func onUpdateMedia(mediaConfig: MediaConfig) {
-        PKLog.debug("plugin \(type(of:self)) onUpdateMedia with media config: \(mediaConfig)")
-        self.mediaEntry = mediaConfig.mediaEntry
-    }
-    
-    public static var pluginName = String(describing: IMAPlugin.self)
-    
-    public func destroy() {
-        PKLog.info("destroying plugin \(type(of:self))")
+    public override func destroy() {
+        super.destroy()
         self.destroyManager()
         self.timer?.invalidate()
     }

--- a/Plugins/KalturaLiveStats/KalturaLiveStatsPlugin.swift
+++ b/Plugins/KalturaLiveStats/KalturaLiveStatsPlugin.swift
@@ -176,7 +176,7 @@ public class KalturaLiveStatsPlugin: BaseAnalyticsPlugin {
     private func sendLiveEvent(theBufferTime: Int32) {
         PKLog.debug("sendLiveEvent - Buffer Time: \(bufferTime)")
         
-        guard let mediaEntry = self.mediaEntry else { return }
+        guard let mediaEntry = self.player.mediaEntry else { return }
         
         var sessionId = ""
         var baseUrl = "https://stats.kaltura.com/api_v3/index.php"

--- a/Plugins/KalturaLiveStats/LiveStatsService.swift
+++ b/Plugins/KalturaLiveStats/LiveStatsService.swift
@@ -46,7 +46,7 @@ internal class LiveStatsService {
             
                 .set(method: .get)
             return request
-        }else{
+        } else {
             return nil
         }
     }

--- a/Plugins/KalturaStats/KalturaStatsPlugin.swift
+++ b/Plugins/KalturaStats/KalturaStatsPlugin.swift
@@ -284,7 +284,7 @@ public class KalturaStatsPlugin: BaseAnalyticsPlugin {
             parterId = String(pId)
         }
         
-        guard let mediaEntry = self.mediaEntry else {
+        guard let mediaEntry = self.player.mediaEntry else {
             PKLog.error("send analytics failed due to nil mediaEntry")
             return
         }

--- a/Plugins/Phoenix/PhoenixAnalyticsPlugin.swift
+++ b/Plugins/Phoenix/PhoenixAnalyticsPlugin.swift
@@ -40,6 +40,7 @@ public class PhoenixAnalyticsPlugin: BaseOTTAnalyticsPlugin {
         
         guard let mediaEntry = self.mediaEntry else {
             PKLog.error("send analytics failed due to nil mediaEntry")
+            self.messageBus.post(PlayerEvent.PluginError(nsError: AnalyticsError.missingMediaEntry.asNSError))
             return nil
         }
         

--- a/Plugins/Phoenix/PhoenixAnalyticsPlugin.swift
+++ b/Plugins/Phoenix/PhoenixAnalyticsPlugin.swift
@@ -40,7 +40,7 @@ public class PhoenixAnalyticsPlugin: BaseOTTAnalyticsPlugin {
         
         guard let mediaEntry = self.player.mediaEntry else {
             PKLog.error("send analytics failed due to nil mediaEntry")
-            self.messageBus.post(PlayerEvent.PluginError(nsError: AnalyticsError.missingMediaEntry.asNSError))
+            self.messageBus.post(PlayerEvent.PluginError(nsError: AnalyticsPluginError.missingMediaEntry.asNSError))
             return nil
         }
         

--- a/Plugins/Phoenix/PhoenixAnalyticsPlugin.swift
+++ b/Plugins/Phoenix/PhoenixAnalyticsPlugin.swift
@@ -38,7 +38,7 @@ public class PhoenixAnalyticsPlugin: BaseOTTAnalyticsPlugin {
             parterId = pId
         }
         
-        guard let mediaEntry = self.mediaEntry else {
+        guard let mediaEntry = self.player.mediaEntry else {
             PKLog.error("send analytics failed due to nil mediaEntry")
             self.messageBus.post(PlayerEvent.PluginError(nsError: AnalyticsError.missingMediaEntry.asNSError))
             return nil

--- a/Plugins/Phoenix/TVPAPIAnalyticsPlugin.swift
+++ b/Plugins/Phoenix/TVPAPIAnalyticsPlugin.swift
@@ -23,13 +23,13 @@ public class TVPAPIAnalyticsPlugin: BaseOTTAnalyticsPlugin {
         
         guard let initObj = self.config?.params["initObj"] as? [String: Any] else {
             PKLog.error("send analytics failed due to no initObj data")
-            self.messageBus.post(PlayerEvent.PluginError(nsError: AnalyticsError.missingInitObject.asNSError))
+            self.messageBus.post(PlayerEvent.PluginError(nsError: AnalyticsPluginError.missingInitObject.asNSError))
             return nil
         }
         
         guard let mediaEntry = self.player.mediaEntry else {
             PKLog.error("send analytics failed due to nil mediaEntry")
-            self.messageBus.post(PlayerEvent.PluginError(nsError: AnalyticsError.missingMediaEntry.asNSError))
+            self.messageBus.post(PlayerEvent.PluginError(nsError: AnalyticsPluginError.missingMediaEntry.asNSError))
             return nil
         }
         

--- a/Plugins/Phoenix/TVPAPIAnalyticsPlugin.swift
+++ b/Plugins/Phoenix/TVPAPIAnalyticsPlugin.swift
@@ -27,7 +27,7 @@ public class TVPAPIAnalyticsPlugin: BaseOTTAnalyticsPlugin {
             return nil
         }
         
-        guard let mediaEntry = self.mediaEntry else {
+        guard let mediaEntry = self.player.mediaEntry else {
             PKLog.error("send analytics failed due to nil mediaEntry")
             self.messageBus.post(PlayerEvent.PluginError(nsError: AnalyticsError.missingMediaEntry.asNSError))
             return nil

--- a/Plugins/Phoenix/TVPAPIAnalyticsPlugin.swift
+++ b/Plugins/Phoenix/TVPAPIAnalyticsPlugin.swift
@@ -23,11 +23,13 @@ public class TVPAPIAnalyticsPlugin: BaseOTTAnalyticsPlugin {
         
         guard let initObj = self.config?.params["initObj"] as? [String: Any] else {
             PKLog.error("send analytics failed due to no initObj data")
+            self.messageBus.post(PlayerEvent.PluginError(nsError: AnalyticsError.missingInitObject.asNSError))
             return nil
         }
         
         guard let mediaEntry = self.mediaEntry else {
             PKLog.error("send analytics failed due to nil mediaEntry")
+            self.messageBus.post(PlayerEvent.PluginError(nsError: AnalyticsError.missingMediaEntry.asNSError))
             return nil
         }
         

--- a/Plugins/Youbora/YouboraManager.swift
+++ b/Plugins/Youbora/YouboraManager.swift
@@ -41,7 +41,7 @@ class YouboraManager: YBPluginGeneric {
     }
     
     override func getResource() -> String {
-        PKLog.trace("Resource")
+        PKLog.debug("Resource")
         return self.mediaEntry?.id ?? ""
     }
     

--- a/Plugins/Youbora/YouboraPlugin.swift
+++ b/Plugins/Youbora/YouboraPlugin.swift
@@ -19,7 +19,7 @@ enum YouboraPluginError: PKError {
     
     var code: Int {
         switch self {
-        case .failedToSetupYouboraManager: return 3000
+        case .failedToSetupYouboraManager: return 4000
         }
     }
     

--- a/Plugins/Youbora/YouboraPlugin.swift
+++ b/Plugins/Youbora/YouboraPlugin.swift
@@ -182,18 +182,27 @@ public class YouboraPlugin: BaseAnalyticsPlugin {
     /************************************************************/
     
     private func setupYouboraManager(completionHandler: ((_ succeeded: Bool) -> Void)? = nil) {
-        if let config = self.config, var media = config.params["media"] as? [String: Any], let mediaEntry = self.player.mediaEntry {
-            media["resource"] = mediaEntry.id
-            media["title"] = mediaEntry.id
-            media["duration"] = self.player.duration
-            config.params["media"] = media
-            youboraManager = YouboraManager(options: config.params as NSObject!, player: player, mediaEntry: mediaEntry)
-            completionHandler?(true)
-        } else {
-            PKLog.error("config params are wrong or doesn't exist, or missing MediaEntry, could not setup youbora manager")
+        
+        guard let config = self.config, var media = config.params["media"] as? [String: Any] else {
+            PKLog.error("config params are wrong or doesn't exist, could not setup youbora manager")
             self.messageBus.post(PlayerEvent.PluginError(nsError: YouboraPluginError.failedToSetupYouboraManager.asNSError))
             completionHandler?(false)
+            return
         }
+        
+        guard let mediaEntry = self.player.mediaEntry else {
+            PKLog.error("missing MediaEntry, could not setup youbora manager")
+            self.messageBus.post(PlayerEvent.PluginError(nsError: YouboraPluginError.failedToSetupYouboraManager.asNSError))
+            completionHandler?(false)
+            return
+        }
+        
+        media["resource"] = mediaEntry.id
+        media["title"] = mediaEntry.id
+        media["duration"] = self.player.duration
+        config.params["media"] = media
+        youboraManager = YouboraManager(options: config.params as NSObject!, player: player, mediaEntry: mediaEntry)
+        completionHandler?(true)
     }
     
     private func startMonitoring(player: Player) {

--- a/Plugins/Youbora/YouboraPlugin.swift
+++ b/Plugins/Youbora/YouboraPlugin.swift
@@ -10,6 +10,32 @@ import YouboraLib
 import YouboraPluginAVPlayer
 import AVFoundation
 
+/// `YouboraPluginError` represents youbora plugin errors.
+enum YouboraPluginError: PKError {
+    
+    case failedToSetupYouboraManager
+    
+    static let Domain = PKErrorDomain.Youbora
+    
+    var code: Int {
+        switch self {
+        case .failedToSetupYouboraManager: return 3000
+        }
+    }
+    
+    var errorDescription: String {
+        switch self {
+        case .failedToSetupYouboraManager: return "failed to setup youbora manager, missing config/config params or mediaEntry"
+        }
+    }
+    
+    var userInfo: [String: Any] {
+        switch self {
+        case .failedToSetupYouboraManager: return [:]
+        }
+    }
+}
+
 public class YouboraPlugin: BaseAnalyticsPlugin {
     
     public override class var pluginName: String {
@@ -164,7 +190,8 @@ public class YouboraPlugin: BaseAnalyticsPlugin {
             youboraManager = YouboraManager(options: config.params as NSObject!, player: player, mediaEntry: mediaEntry)
             completionHandler?(true)
         } else {
-            PKLog.warning("There is no config params or MediaEntry, could not setup youbora manager")
+            PKLog.error("config params are wrong or doesn't exist, or missing MediaEntry, could not setup youbora manager")
+            self.messageBus.post(PlayerEvent.PluginError(nsError: YouboraPluginError.failedToSetupYouboraManager.asNSError))
             completionHandler?(false)
         }
     }

--- a/Plugins/Youbora/YouboraPlugin.swift
+++ b/Plugins/Youbora/YouboraPlugin.swift
@@ -182,7 +182,7 @@ public class YouboraPlugin: BaseAnalyticsPlugin {
     /************************************************************/
     
     private func setupYouboraManager(completionHandler: ((_ succeeded: Bool) -> Void)? = nil) {
-        if let config = self.config, var media = config.params["media"] as? [String: Any], let mediaEntry = self.mediaEntry {
+        if let config = self.config, var media = config.params["media"] as? [String: Any], let mediaEntry = self.player.mediaEntry {
             media["resource"] = mediaEntry.id
             media["title"] = mediaEntry.id
             media["duration"] = self.player.duration

--- a/Plugins/Youbora/YouboraPlugin.swift
+++ b/Plugins/Youbora/YouboraPlugin.swift
@@ -10,12 +10,16 @@ import YouboraLib
 import YouboraPluginAVPlayer
 import AVFoundation
 
+/************************************************************/
+// MARK: - YouboraPluginError
+/************************************************************/
+
 /// `YouboraPluginError` represents youbora plugin errors.
 enum YouboraPluginError: PKError {
     
     case failedToSetupYouboraManager
     
-    static let Domain = PKErrorDomain.Youbora
+    static let Domain = "com.kaltura.playkit.error.youbora"
     
     var code: Int {
         switch self {
@@ -35,6 +39,14 @@ enum YouboraPluginError: PKError {
         }
     }
 }
+
+extension PKErrorDomain {
+    public static let Youbora = YouboraPluginError.Domain
+}
+
+/************************************************************/
+// MARK: - YouboraPlugin
+/************************************************************/
 
 public class YouboraPlugin: BaseAnalyticsPlugin {
     


### PR DESCRIPTION
This PR contains error handling and logging improvements.
* Added concrete errors for plugins and player (in next phase will add more domains).
* Added and improved logging.
* general fixes and improvements.

* New data accessor for `PKEvent`: `adError` under `AdEvent`.
So now when we get a `PKEvent` we can access `adError` like this `event.adError`.

* Added 2 new error events in order to separate observation per error type.
`PlayerEvent` has a new error type for plugins errors: `PlayerEvent.PluginError`.
`AdEvent` has a new error type for ads: `AdEvent.Error`
