### PR TITLE
Feo 7394

### DIFF
--- a/Classes/Network/KalturaMultiRequestBuilder.swift
+++ b/Classes/Network/KalturaMultiRequestBuilder.swift
@@ -26,7 +26,7 @@ class KalturaMultiRequestBuilder: KalturaRequestBuilder {
     override public func build() -> Request {
         
         let data = self.kalturaMultiRequestData()
-        let request = RequestElement(requestId: self.requestId, method: self.method, url: self.url, dataBody: data, headers: self.headers, timeout: self.timeout, configuration: self.configuration, responseSerializer:self.responseSerializer, completion: self.completion)
+        let request = RequestElement(requestId: self.requestId, method: self.method, url: self.url, dataBody: data, headers: self.headers, timeout: self.timeout, configuration: self.configuration, responseSerializer: self.responseSerializer, completion: self.completion)
         
         return request
     }

--- a/Classes/Network/KalturaMultiRequestBuilder.swift
+++ b/Classes/Network/KalturaMultiRequestBuilder.swift
@@ -26,7 +26,7 @@ class KalturaMultiRequestBuilder: KalturaRequestBuilder {
     override public func build() -> Request {
         
         let data = self.kalturaMultiRequestData()
-        let request = RequestElement(requestId: self.requestId, method: self.method, url: self.url, dataBody: data, headers: self.headers, timeout: self.timeout, configuration: self.configuration, completion: self.completion)
+        let request = RequestElement(requestId: self.requestId, method: self.method, url: self.url, dataBody: data, headers: self.headers, timeout: self.timeout, configuration: self.configuration, responseSerializer:self.responseSerializer, completion: self.completion)
         
         return request
     }

--- a/Classes/Network/Request.swift
+++ b/Classes/Network/Request.swift
@@ -34,6 +34,7 @@ public protocol Request {
     var timeout: Double { get }
     var configuration: RequestConfiguration? { get }
     var completion: completionClosures? { get }
+    var responseSerializer: ResponseSerializer { get }
 }
 
 public struct RequestElement: Request {
@@ -45,6 +46,7 @@ public struct RequestElement: Request {
     public var headers: [String:String]?
     public var timeout: Double
     public var configuration: RequestConfiguration?
+    public var responseSerializer: ResponseSerializer
     public var completion: completionClosures?
 }
 
@@ -62,7 +64,7 @@ public struct RequestElement: Request {
     public var configuration: RequestConfiguration? = nil
     public var completion: completionClosures? = nil
     public var urlParams: [String: String]? = nil
-    
+    public var responseSerializer : ResponseSerializer = JSONSerializer()
     public init?(url: String){
         if let path = URL(string: url) {
             self.url = path
@@ -98,6 +100,12 @@ public struct RequestElement: Request {
     @discardableResult
     public func set(configuration:RequestConfiguration?) -> Self{
         self.configuration = configuration
+        return self
+    }
+    
+    @discardableResult
+    public func set(responseSerializer: ResponseSerializer) -> Self{
+        self.responseSerializer = responseSerializer
         return self
     }
     
@@ -170,7 +178,7 @@ public struct RequestElement: Request {
             
         }
         
-        return RequestElement(requestId: self.requestId, method:self.method , url: self.url, dataBody: bodyData, headers: self.headers, timeout: self.timeout, configuration: self.configuration, completion: self.completion)
+        return RequestElement(requestId: self.requestId, method:self.method , url: self.url, dataBody: bodyData, headers: self.headers, timeout: self.timeout, configuration: self.configuration,responseSerializer: self.responseSerializer, completion: self.completion)
     }
 }
 

--- a/Classes/Network/ResponseSerializer.swift
+++ b/Classes/Network/ResponseSerializer.swift
@@ -17,13 +17,13 @@ public protocol ResponseSerializer {
     /**
      This fuction will serialize the response data of certin request to the expected type according to the serializer type
      */
-    func serialize(data:Data) throws -> Any
+    func serialize(data: Data) throws -> Any
 }
 
 
  class JSONSerializer: ResponseSerializer {
     
-    func serialize(data:Data) throws -> Any {
+    func serialize(data: Data) throws -> Any {
         let json = try JSONSerialization.jsonObject(with: data, options: JSONSerialization.ReadingOptions())
         return json
     }
@@ -32,7 +32,7 @@ public protocol ResponseSerializer {
 
  class IntSerializer: ResponseSerializer {
     
-    func serialize(data:Data) throws -> Any {
+    func serialize(data: Data) throws -> Any {
         guard let int8 = [UInt8](data).last else {
            throw SerializerError.serializationError
         }
@@ -44,11 +44,8 @@ public protocol ResponseSerializer {
 
  class StringSerializer: ResponseSerializer {
     
-    func serialize(data:Data) throws -> Any {
+    func serialize(data: Data) throws -> Any {
         let string = String(data: data, encoding: .utf8)
         return string
     }
 }
-
-
-

--- a/Classes/Network/ResponseSerializer.swift
+++ b/Classes/Network/ResponseSerializer.swift
@@ -1,0 +1,54 @@
+//
+//  ResponseSerializer.swift
+//  Pods
+//
+//  Created by Rivka Peleg on 14/03/2017.
+//
+//
+
+import Foundation
+
+enum SerializerError: Error {
+    case serializationError
+}
+
+
+public protocol ResponseSerializer {
+    /**
+     This fuction will serialize the response data of certin request to the expected type according to the serializer type
+     */
+    func serialize(data:Data) throws -> Any
+}
+
+
+ class JSONSerializer: ResponseSerializer {
+    
+    func serialize(data:Data) throws -> Any {
+        let json = try JSONSerialization.jsonObject(with: data, options: JSONSerialization.ReadingOptions())
+        return json
+    }
+}
+
+
+ class IntSerializer: ResponseSerializer {
+    
+    func serialize(data:Data) throws -> Any {
+        guard let int8 = [UInt8](data).last else {
+           throw SerializerError.serializationError
+        }
+        
+        let int: Int = Int(int8)
+        return int
+    }
+}
+
+ class StringSerializer: ResponseSerializer {
+    
+    func serialize(data:Data) throws -> Any {
+        let string = String(data: data, encoding: .utf8)
+        return string
+    }
+}
+
+
+

--- a/Classes/Network/USRExecutor.swift
+++ b/Classes/Network/USRExecutor.swift
@@ -78,7 +78,7 @@ import UIKit
                     
                     if let d = data {
                         do {
-                            let json = try JSONSerialization.jsonObject(with: d, options: JSONSerialization.ReadingOptions())
+                            let json = try r.responseSerializer.serialize(data: d)
                             let result = Response(data: json, error:nil)
                             completion(result)
                         } catch {

--- a/Plugins/Phoenix/TVPAPIAnalyticsPlugin.swift
+++ b/Plugins/Phoenix/TVPAPIAnalyticsPlugin.swift
@@ -52,7 +52,7 @@ public class TVPAPIAnalyticsPlugin: BaseOTTAnalyticsPlugin {
                                                                                     fileId: fileId) else {
             return nil
         }
-        
+        requestBuilder.set(responseSerializer: StringSerializer())
         requestBuilder.set { (response: Response) in
             PKLog.trace("Response: \(response)")
             if response.statusCode == 0 {

--- a/Plugins/Phoenix/TVPAPIAnalyticsPlugin.swift
+++ b/Plugins/Phoenix/TVPAPIAnalyticsPlugin.swift
@@ -57,7 +57,7 @@ public class TVPAPIAnalyticsPlugin: BaseOTTAnalyticsPlugin {
             PKLog.trace("Response: \(response)")
             if response.statusCode == 0 {
                 PKLog.trace("\(response.data)")
-                guard let data = response.data as? String, data.lowercased() == "concurrent" else { return }
+                guard let data = response.data as? String, data.lowercased() == "\"concurrent\"" else { return }
                 self.reportConcurrencyEvent()
             }
         }


### PR DESCRIPTION
This Pull request adding the option to set serializer to the request instead of always using JSONSerialization. 

by default all requests will be created with JSONSerializer , and for certain cases we can set the serializer to string or int or any other serializer that conforms to the ResponseSerializer protocol.