### PR TITLE
#FEM-1296

### DIFF
--- a/Classes/Player/AVPlayerEngine/AVPlayerEngine.swift
+++ b/Classes/Player/AVPlayerEngine/AVPlayerEngine.swift
@@ -197,7 +197,7 @@ class AVPlayerEngine: AVPlayer {
     func destroy() {
         PKLog.trace("destory player")
         self.nonObservablePropertiesUpdateTimer?.invalidate()
-        self.nonObservablePropertiesUpdateTimer == nil
+        self.nonObservablePropertiesUpdateTimer = nil
         self.removeObservers()
         self.avPlayerLayer = nil
         self._view = nil

--- a/Plugins/IMA/IMAPlugin.swift
+++ b/Plugins/IMA/IMAPlugin.swift
@@ -301,7 +301,7 @@ extension IMAAdsManager {
         case .STARTED:
             if let ad = event.ad {
                 let adInfo = PKAdInfo(ad: ad)
-                self.notify(event: AdEvent.AdInfomation(adInfo: adInfo))
+                self.notify(event: AdEvent.AdInformation(adInfo: adInfo))
             }
             self.notify(event: AdEvent.AdStarted())
             self.showLoadingView(false, alpha: 0)

--- a/Plugins/IMA/PKAdInfo.swift
+++ b/Plugins/IMA/PKAdInfo.swift
@@ -91,9 +91,9 @@ import GoogleInteractiveMediaAds
 
 extension AdEvent {
     
-    @objc public static let adInformation: AdEvent.Type = AdInfomation.self
+    @objc public static let adInformation: AdEvent.Type = AdInformation.self
     
-    class AdInfomation: AdEvent {
+    class AdInformation: AdEvent {
         convenience init(adInfo: PKAdInfo) {
             self.init([AdEventDataKeys.adInfo: adInfo])
         }


### PR DESCRIPTION
* Prevented ads player decorator from sending play() after post-roll content resume.
* Fixed typo with AdInformation event was missing ‘r’.