### PR TITLE
#FEM-1297

### DIFF
--- a/Classes/PKError.swift
+++ b/Classes/PKError.swift
@@ -51,7 +51,7 @@ enum PlayerError: PKError {
     }
 }
 
-/// `PlayerErrorLog` represents an error log emited from AVPlayer (usually non-fatal).
+/// `PlayerErrorLog` represents an error log emitted from AVPlayer (usually non-fatal).
 struct PlayerErrorLog: PKError {
     
     static var domain = PlayerError.domain
@@ -66,7 +66,7 @@ struct PlayerErrorLog: PKError {
         return errorLogEvent.errorComment ?? ""
     }
     
-    var userInfo: [String : Any] {
+    var userInfo: [String: Any] {
         return [
             PKErrorKeys.RootCodeKey: errorLogEvent.errorStatusCode,
             PKErrorKeys.RootDomainKey: errorLogEvent.errorDomain

--- a/Classes/PKError.swift
+++ b/Classes/PKError.swift
@@ -19,7 +19,6 @@ enum PlayerError: PKError {
     case failedToLoadAssetFromKeys(rootError: NSError?)
     case assetNotPlayable
     case failedToPlayToEndTime(rootError: NSError)
-    case playerItemErrorLogEvent(errorLogEvent: AVPlayerItemErrorLogEvent)
     
     static let domain = "com.kaltura.playkit.error.player"
     
@@ -28,7 +27,6 @@ enum PlayerError: PKError {
         case .failedToLoadAssetFromKeys: return PKErrorCode.failedToLoadAssetFromKeys
         case .assetNotPlayable: return PKErrorCode.assetNotPlayable
         case .failedToPlayToEndTime: return PKErrorCode.failedToPlayToEndTime
-        case .playerItemErrorLogEvent: return PKErrorCode.playerItemErrorLogEvent
         }
     }
     
@@ -37,7 +35,6 @@ enum PlayerError: PKError {
         case .failedToLoadAssetFromKeys: return "Can't use this AVAsset because one of it's keys failed to load"
         case .assetNotPlayable: return "Can't use this AVAsset because it isn't playable"
         case .failedToPlayToEndTime: return "Item failed to play to its end time"
-        case .playerItemErrorLogEvent(let errorLogEvent): return errorLogEvent.errorComment ?? ""
         }
     }
     
@@ -50,12 +47,30 @@ enum PlayerError: PKError {
             return [:]
         case .assetNotPlayable: return [:]
         case .failedToPlayToEndTime(let rootError): return [PKErrorKeys.RootErrorKey: rootError]
-        case .playerItemErrorLogEvent(let errorLogEvent):
-            return [
-                PKErrorKeys.RootCodeKey: errorLogEvent.errorStatusCode,
-                PKErrorKeys.RootDomainKey: errorLogEvent.errorDomain
-            ]
         }
+    }
+}
+
+/// `PlayerErrorLog` represents an error log emited from AVPlayer (usually non-fatal).
+struct PlayerErrorLog: PKError {
+    
+    static var domain = PlayerError.domain
+    
+    let errorLogEvent: AVPlayerItemErrorLogEvent
+    
+    var code: Int {
+        return PKErrorCode.playerItemErrorLogEvent
+    }
+    
+    var errorDescription: String {
+        return errorLogEvent.errorComment ?? ""
+    }
+    
+    var userInfo: [String : Any] {
+        return [
+            PKErrorKeys.RootCodeKey: errorLogEvent.errorStatusCode,
+            PKErrorKeys.RootDomainKey: errorLogEvent.errorDomain
+        ]
     }
 }
 
@@ -111,7 +126,7 @@ protocol PKError: Error, CustomStringConvertible {
     
     /**
      The error code.
-     use `switch self` to retrive the value in **enums**.
+     use `switch self` to retrieve the value in **enums**.
      
      ````
      var code: Int {

--- a/Classes/PKError.swift
+++ b/Classes/PKError.swift
@@ -237,7 +237,8 @@ struct PKErrorKeys {
     @objc(FailedToLoadAssetFromKeys) public static let failedToLoadAssetFromKeys = 7000
     @objc(AssetNotPlayable) public static let assetNotPlayable = 7001
     @objc(FailedToPlayToEndTime) public static let failedToPlayToEndTime = 7002
-    @objc(PlayerItemErrorLogEvent) public static let playerItemErrorLogEvent = 7003
+    // PlayerErrorLog
+    @objc(PlayerItemErrorLogEvent) public static let playerItemErrorLogEvent = 7100
     // PKPluginError
     @objc(FailedToCreatePlugin) public static let failedToCreatePlugin = 2000
     @objc(MissingPluginConfig) public static let missingPluginConfig = 2001

--- a/Classes/Player/AVPlayerEngine/AVPlayerEngine+Observation.swift
+++ b/Classes/Player/AVPlayerEngine/AVPlayerEngine+Observation.swift
@@ -75,8 +75,8 @@ extension AVPlayerEngine {
     
     func onErrorLogEntryNotification(notification: Notification) {
         guard let playerItem = notification.object as? AVPlayerItem, let errorLog = playerItem.errorLog(), let lastEvent = errorLog.events.last else { return }
-        PKLog.error("error description: \(lastEvent.errorComment), error domain: \(lastEvent.errorDomain), error code: \(lastEvent.errorStatusCode)")
-        self.post(event: PlayerEvent.Error(error: PlayerError.playerItemErrorLogEvent(errorLogEvent: lastEvent)))
+        PKLog.warning("error description: \(String(describing: lastEvent.errorComment)), error domain: \(lastEvent.errorDomain), error code: \(lastEvent.errorStatusCode)")
+        self.post(event: PlayerEvent.ErrorLog(error: PlayerErrorLog(errorLogEvent: lastEvent)))
     }
     
     public func playerFailed(notification: NSNotification) {

--- a/Classes/PlayerEvent.swift
+++ b/Classes/PlayerEvent.swift
@@ -51,6 +51,8 @@ import AVFoundation
     @objc public static let error: PlayerEvent.Type = Error.self
     /// Sent when an plugin error occurs.
     @objc public static let pluginError: PlayerEvent.Type = PluginError.self
+    /// Sent when an error log event received from player.
+    @objc public static let errorLog: PlayerEvent.Type = ErrorLog.self
     
     // MARK: - Player Basic Events
 
@@ -80,6 +82,16 @@ import AVFoundation
     }
     
     class PluginError: PlayerEvent {
+        convenience init(nsError: NSError) {
+            self.init([EventDataKeys.Error: nsError])
+        }
+        
+        convenience init(error: PKError) {
+            self.init([EventDataKeys.Error: error.asNSError])
+        }
+    }
+    
+    class ErrorLog: PlayerEvent {
         convenience init(nsError: NSError) {
             self.init([EventDataKeys.Error: nsError])
         }


### PR DESCRIPTION
* Separated player error log events from regular errors.
Now use errorLog type to observe error log events. Could be helpful for debug and analytics.