### PR TITLE
#FEM-1314

### DIFF
--- a/Classes/Player/AVPlayerEngine/AVPlayerEngine+AssetLoading.swift
+++ b/Classes/Player/AVPlayerEngine/AVPlayerEngine+AssetLoading.swift
@@ -60,6 +60,9 @@ extension AVPlayerEngine {
                     return
                 }
                 
+                // When changing media (loading new asset) we want to reset isFirstReady in order to receive `CanPlay` & `LoadedMetadata` accuratly.
+                self.isFirstReady = true
+                    
                 /*
                  We can play this asset. Create a new `AVPlayerItem` and make
                  it our player's current item.

--- a/Classes/Player/AVPlayerEngine/AVPlayerEngine+Observation.swift
+++ b/Classes/Player/AVPlayerEngine/AVPlayerEngine+Observation.swift
@@ -183,7 +183,6 @@ extension AVPlayerEngine {
     private func handleStatusChange() {
         if currentItem?.status == .readyToPlay {
             let newState = PlayerState.ready
-            self.post(event: PlayerEvent.LoadedMetadata())
             
             if self.startPosition > 0 {
                 self.currentPosition = self.startPosition
@@ -197,7 +196,11 @@ extension AVPlayerEngine {
             self.postStateChange(newState: newState, oldState: self.currentState)
             self.currentState = newState
             
-            self.post(event: PlayerEvent.CanPlay())
+            if self.isFirstReady {
+                self.isFirstReady = false
+                self.post(event: PlayerEvent.LoadedMetadata())
+                self.post(event: PlayerEvent.CanPlay())
+            }
         } else if currentItem?.status == .failed {
             let newState = PlayerState.error
             self.postStateChange(newState: newState, oldState: self.currentState)

--- a/Classes/Player/AVPlayerEngine/AVPlayerEngine.swift
+++ b/Classes/Player/AVPlayerEngine/AVPlayerEngine.swift
@@ -27,10 +27,13 @@ class AVPlayerEngine: AVPlayer {
     private var avPlayerLayer: AVPlayerLayer!
     private var _view: PlayerView!
     private var isDestroyed = false
-    
+    /// Keeps reference on the last timebase rate in order to post events accuratly.
     var lastTimebaseRate: Float64 = 0
     var lastBitrate: Double = 0
     var isObserved: Bool = false
+    /// Indicates if player item was changed to state: `readyToPlay` at least once.
+    /// Used to post `CanPlay` event once on first `readyToPlay`.
+    var isFirstReady = true
     var currentState: PlayerState = PlayerState.idle
     var tracksManager = TracksManager()
     var observerContext = 0


### PR DESCRIPTION
* Added `isFirstReady` flag to indicate first time the player was in ready to play state.
This helps fix an issue where can play event would be posted numerous times.