### PR TITLE
Fixed getPreferredDownloadableMediaSource

### DIFF
--- a/Classes/Managers/LocalAssetsManager.swift
+++ b/Classes/Managers/LocalAssetsManager.swift
@@ -109,7 +109,7 @@ import AVFoundation
                 return source
             }
         } else {
-            if let source = sources.first(where: {$0.fileExt=="m3u8" && $0.drmData==nil}) {
+            if let source = sources.first(where: {$0.fileExt=="m3u8" && ($0.drmData == nil || $0.drmData!.isEmpty)}) {
                 return source
             }
         }


### PR DESCRIPTION
A source with drmParams != nil but empty should be considered clear.