### PR TITLE
Adding MediaProvider Response Listener

### DIFF
--- a/Classes/Providers/MediaEntryProviderResponseDelegate.swift
+++ b/Classes/Providers/MediaEntryProviderResponseDelegate.swift
@@ -1,0 +1,18 @@
+//
+//  MediaEntryProviderResponseDelegate.swift
+//  Pods
+//
+//  Created by Rivka Peleg on 03/07/2017.
+//
+//
+
+import Foundation
+
+//This protocol provides a way to use the response data of the requests are being sent by MediaEntryProvider.
+//For example the response of getPlaybackContext, or additional meta data.
+
+@objc public protocol MediaEntryProviderResponseDelegate {
+    
+    @objc func providerGotResponse(sender:MediaEntryProvider?, response: [String:Any]?) -> Void
+
+}

--- a/Classes/Providers/MediaEntryProviderResponseDelegate.swift
+++ b/Classes/Providers/MediaEntryProviderResponseDelegate.swift
@@ -7,12 +7,13 @@
 //
 
 import Foundation
+import KalturaNetKit
 
 //This protocol provides a way to use the response data of the requests are being sent by MediaEntryProvider.
 //For example the response of getPlaybackContext, or additional meta data.
 
-@objc public protocol MediaEntryProviderResponseDelegate {
+public protocol MediaEntryProviderResponseDelegate: class {
     
-    @objc func providerGotResponse(sender: MediaEntryProvider?, response: [String:Any]?) -> Void
+    func providerGotResponse(sender: MediaEntryProvider?, response: Response) -> Void
 
 }

--- a/Classes/Providers/MediaEntryProviderResponseDelegate.swift
+++ b/Classes/Providers/MediaEntryProviderResponseDelegate.swift
@@ -13,6 +13,6 @@ import Foundation
 
 @objc public protocol MediaEntryProviderResponseDelegate {
     
-    @objc func providerGotResponse(sender:MediaEntryProvider?, response: [String:Any]?) -> Void
+    @objc func providerGotResponse(sender: MediaEntryProvider?, response: [String:Any]?) -> Void
 
 }

--- a/Classes/Providers/OTT/PhoenixMediaProvider.swift
+++ b/Classes/Providers/OTT/PhoenixMediaProvider.swift
@@ -318,7 +318,7 @@ public enum PhoenixMediaProviderError: PKError {
             let request = requestBuilder.set(completion: { (response: Response) in
 
                 if let delegate = self.responseDelegate {
-                   delegate.providerGotResponse(sender: self, response: (response.data as? [String : Any]))
+                    delegate.providerGotResponse(sender: self, response: (response.data as? [String: Any]))
                 }
                 
                 if let error = response.error {

--- a/Classes/Providers/OTT/PhoenixMediaProvider.swift
+++ b/Classes/Providers/OTT/PhoenixMediaProvider.swift
@@ -129,6 +129,7 @@ public enum PhoenixMediaProviderError: PKError {
     @objc public var fileIds: [String]?
     @objc public var playbackContextType: PlaybackContextType = .unknown
     @objc public var networkProtocol: String?
+    @objc public weak var responseDelegate: MediaEntryProviderResponseDelegate? = nil
     
     public var executor: RequestExecutor?
 
@@ -205,6 +206,20 @@ public enum PhoenixMediaProviderError: PKError {
         self.executor = executor
         return self
     }
+    
+    
+    /// - Parameter responseDelegate: responseDelegate which will be used to get the response of the requests are being sent by the mediaProvider
+    ///    default is nil
+    /// - Returns: Self
+    @discardableResult
+    @nonobjc public func set(responseDelegate: MediaEntryProviderResponseDelegate?) -> Self {
+        self.responseDelegate = responseDelegate
+        return self
+    }
+
+    
+    
+    
 
     let defaultProtocol = "https"
 
@@ -302,6 +317,10 @@ public enum PhoenixMediaProviderError: PKError {
 
             let request = requestBuilder.set(completion: { (response: Response) in
 
+                if let delegate = self.responseDelegate {
+                   delegate.providerGotResponse(sender: self, response: (response.data as? [String : Any]))
+                }
+                
                 if let error = response.error {
                     // if error is of type `PKError` pass it as `NSError` else pass the `Error` object.
                     callback(nil, (error as? PKError)?.asNSError ?? error)

--- a/Classes/Providers/OTT/PhoenixMediaProvider.swift
+++ b/Classes/Providers/OTT/PhoenixMediaProvider.swift
@@ -129,7 +129,7 @@ public enum PhoenixMediaProviderError: PKError {
     @objc public var fileIds: [String]?
     @objc public var playbackContextType: PlaybackContextType = .unknown
     @objc public var networkProtocol: String?
-    @objc public weak var responseDelegate: MediaEntryProviderResponseDelegate? = nil
+    public weak var responseDelegate: MediaEntryProviderResponseDelegate? = nil
     
     public var executor: RequestExecutor?
 
@@ -318,7 +318,7 @@ public enum PhoenixMediaProviderError: PKError {
             let request = requestBuilder.set(completion: { (response: Response) in
 
                 if let delegate = self.responseDelegate {
-                    delegate.providerGotResponse(sender: self, response: (response.data as? [String: Any]))
+                    delegate.providerGotResponse(sender: self, response: response)
                 }
                 
                 if let error = response.error {


### PR DESCRIPTION
Adding a way to listen to the response of the getPlaybackContext and other requests are being sent by the mediaEntryProvider