### PR TITLE
Make player on the PlayerView public

### DIFF
--- a/Classes/Player/PlayerView.swift
+++ b/Classes/Player/PlayerView.swift
@@ -14,7 +14,7 @@ import AVFoundation
 /// A simple `UIView` subclass that is backed by an `AVPlayerLayer` layer.
 public class PlayerView: UIView {
     
-    var player: AVPlayer? {
+    public var player: AVPlayer? {
         get {
             return playerLayer.player
         }


### PR DESCRIPTION
* Some playback services (one of which is Conviva) do need to be
initialized with an AVPlayer to work, so PlayKit should provide
that to the user.