### PR TITLE
#FEM-1557

### DIFF
--- a/Classes/Events/PlayerEvent.swift
+++ b/Classes/Events/PlayerEvent.swift
@@ -53,7 +53,10 @@ import AVFoundation
     @objc public static let timedMetadata: PlayerEvent.Type = TimedMetadata.self
     /// Sent when source was selected.
     @objc public static let sourceSelected: PlayerEvent.Type = SourceSelected.self
-    
+    /// Sent when loaded time ranges was changed, loaded time ranges represent the buffered content.
+    /// could be used to show amount buffered on the playhead UI.
+    @objc public static let loadedTimeRanges: PlayerEvent.Type = LoadedTimeRanges.self
+
     /// Sent when an error occurs in the player that the playback can recover from.
     @objc public static let error: PlayerEvent.Type = Error.self
     /// Sent when a plugin error occurs.
@@ -121,8 +124,6 @@ import AVFoundation
         }
     }
     
-    // MARK: - Player Tracks Events
-    
     class TracksAvailable: PlayerEvent {
         convenience init(tracks: PKTracks) {
             self.init([EventDataKeys.tracks: tracks])
@@ -134,13 +135,17 @@ import AVFoundation
             self.init([EventDataKeys.playbackInfo: playbackInfo])
         }
     }
-    
-    // MARK: - Player State Events
 
     class StateChanged: PlayerEvent {
         convenience init(newState: PlayerState, oldState: PlayerState) {
             self.init([EventDataKeys.newState: newState as AnyObject,
                        EventDataKeys.oldState: oldState as AnyObject])
+        }
+    }
+    
+    class LoadedTimeRanges: PlayerEvent {
+        convenience init(timeRanges: [PKTimeRange]) {
+            self.init([EventDataKeys.timeRanges: timeRanges])
         }
     }
 }

--- a/Classes/Models/PKTimeRange.swift
+++ b/Classes/Models/PKTimeRange.swift
@@ -1,0 +1,32 @@
+//
+//  PKTimeRange.swift
+//  Pods
+//
+//  Created by Gal Orlanczyk on 24/07/2017.
+//
+//
+
+import Foundation
+import CoreMedia
+
+@objc public class PKTimeRange: NSObject {
+    @objc public let start: TimeInterval
+    @objc public let end: TimeInterval
+    @objc public let duration: TimeInterval
+    
+    public override var description: String {
+        return "[\(String(describing: type(of: self)))] - start: \(self.start), end: \(self.end), duration: \(self.duration)"
+    }
+    
+    init(start: TimeInterval, duration: TimeInterval) {
+        self.start = start
+        self.duration = duration
+        self.end = start + duration
+    }
+    
+    convenience init(timeRange: CMTimeRange) {
+        let start = CMTimeGetSeconds(timeRange.start)
+        let duration = CMTimeGetSeconds(timeRange.duration)
+        self.init(start: start, duration: duration)
+    }
+}

--- a/Classes/Player/AVPlayerEngine/AVPlayerEngine+Observation.swift
+++ b/Classes/Player/AVPlayerEngine/AVPlayerEngine+Observation.swift
@@ -23,6 +23,8 @@ extension AVPlayerEngine {
             #keyPath(currentItem.status),
             #keyPath(currentItem.playbackLikelyToKeepUp),
             #keyPath(currentItem.playbackBufferEmpty),
+            #keyPath(currentItem.isPlaybackBufferFull),
+            #keyPath(currentItem.loadedTimeRanges),
             #keyPath(currentItem.timedMetadata)
         ]
     }
@@ -119,6 +121,12 @@ extension AVPlayerEngine {
         switch keyPath {
         case #keyPath(currentItem.playbackLikelyToKeepUp): self.handleLikelyToKeepUp()
         case #keyPath(currentItem.playbackBufferEmpty): self.handleBufferEmptyChange()
+        case #keyPath(currentItem.isPlaybackBufferFull): PKLog.debug("Buffer Full")
+        case #keyPath(currentItem.loadedTimeRanges):
+            guard let loadedTimeRanges = self.currentItem?.loadedTimeRanges else { return }
+            // convert values to PKTimeRange
+            let timeRanges = loadedTimeRanges.map { PKTimeRange(timeRange: $0.timeRangeValue) }
+            self.post(event: PlayerEvent.LoadedTimeRanges(timeRanges: timeRanges))
         case #keyPath(rate): self.handleRate()
         case #keyPath(status):
             guard let statusChange = change?[.newKey] as? NSNumber, let newPlayerStatus = AVPlayerStatus(rawValue: statusChange.intValue) else {

--- a/Classes/Player/PKEvent.swift
+++ b/Classes/Player/PKEvent.swift
@@ -47,6 +47,7 @@ public extension PKEvent {
         static let error = "error"
         static let metadata = "metadata"
         static let mediaSource = "mediaSource"
+        static let timeRanges = "timeRanges"
     }
     
     // MARK: Player Data Accessors
@@ -97,5 +98,10 @@ public extension PKEvent {
     /// Content url, PKEvent Data Accessor
     @objc public var mediaSource: MediaSource? {
         return self.data?[EventDataKeys.mediaSource] as? MediaSource
+    }
+    
+    /// Content url, PKEvent Data Accessor
+    @objc public var timeRanges: [PKTimeRange]? {
+        return self.data?[EventDataKeys.timeRanges] as? [PKTimeRange]
     }
 }

--- a/Classes/Player/Player.swift
+++ b/Classes/Player/Player.swift
@@ -58,6 +58,9 @@ import AVKit
     /// Indicates the desired rate of playback, 0.0 means "paused", 1.0 indicates a desire to play at the natural rate of the current item.
     @objc var rate: Float { get }
     
+    /// Provides a collection of time ranges for which the player has the media data readily available. The ranges provided might be discontinuous.
+    @objc var loadedTimeRanges: [PKTimeRange]? { get }
+    
     /// Prepare for playing an entry. play when it's ready. (preparing starts buffering the entry)
     @objc func prepare(_ config: MediaConfig)
     

--- a/Classes/Player/PlayerController.swift
+++ b/Classes/Player/PlayerController.swift
@@ -83,6 +83,10 @@ class PlayerController: NSObject, Player, PlayerSettings {
         return self.currentPlayer.rate
     }
     
+    public var loadedTimeRanges: [PKTimeRange]? {
+        return self.currentPlayer.currentItem?.loadedTimeRanges.map { PKTimeRange(timeRange: $0.timeRangeValue) }
+    }
+    
     let sessionUUID = UUID()
     var mediaSessionUUID: UUID?
     

--- a/Classes/Player/PlayerDecoratorBase.swift
+++ b/Classes/Player/PlayerDecoratorBase.swift
@@ -79,6 +79,10 @@ import AVKit
         return self.player.rate
     }
     
+    @objc public var loadedTimeRanges: [PKTimeRange]? {
+        return self.player.loadedTimeRanges
+    }
+    
     open func prepare(_ config: MediaConfig) {
         return self.player.prepare(config)
     }


### PR DESCRIPTION
* Added `PKTimeRange` to represent time ranges.
* Added `loadedTimeRanges` property on player to represent the loaded time ranges readily available for playback.
* Added `LoadedTimeRanges` event for observing changes in loaded time ranges.