### PR TITLE
FEM-1563 #comment NYT initial integration

### DIFF
--- a/Classes/Player/AVPlayerEngine/AVPlayerEngine+AssetLoading.swift
+++ b/Classes/Player/AVPlayerEngine/AVPlayerEngine+AssetLoading.swift
@@ -13,7 +13,7 @@ import AVFoundation
 
 extension AVPlayerEngine {
     
-    override func replaceCurrentItem(with item: AVPlayerItem?) {
+    override public func replaceCurrentItem(with item: AVPlayerItem?) {
         // when changing asset reset last timebase
         self.lastTimebaseRate = 0
         // When changing media (loading new asset) we want to reset isFirstReady in order to receive `CanPlay` & `LoadedMetadata` accuratly.

--- a/Classes/Player/AVPlayerEngine/AVPlayerEngine+Observation.swift
+++ b/Classes/Player/AVPlayerEngine/AVPlayerEngine+Observation.swift
@@ -104,7 +104,7 @@ extension AVPlayerEngine {
         self.post(event: PlayerEvent.Ended())
     }
     
-    override func observeValue(forKeyPath keyPath: String?, of object: Any?, change: [NSKeyValueChangeKey : Any]?, context: UnsafeMutableRawPointer?) {
+    override public func observeValue(forKeyPath keyPath: String?, of object: Any?, change: [NSKeyValueChangeKey : Any]?, context: UnsafeMutableRawPointer?) {
         PKLog.debug("observeValue:: onEvent/onState")
         
         guard context == &observerContext else {

--- a/Classes/Player/AVPlayerEngine/AVPlayerEngine.swift
+++ b/Classes/Player/AVPlayerEngine/AVPlayerEngine.swift
@@ -15,7 +15,7 @@ import CoreMedia
 
 /// An AVPlayerEngine is a controller used to manage the playback and timing of a media asset.
 /// It provides the interface to control the player’s behavior such as its ability to play, pause, and seek to various points in the timeline.
-class AVPlayerEngine: AVPlayer {
+public class AVPlayerEngine: AVPlayer {
     
     // MARK: Player Properties
     
@@ -181,7 +181,7 @@ class AVPlayerEngine: AVPlayer {
         self.post(event: PlayerEvent.Stopped())
     }
     
-    override func pause() {
+    override public func pause() {
         // makes sure play/pause call is made on the main thread (calling on background thread has unpredictable behaviours)
         DispatchQueue.main.async {
             if self.rate > 0 {
@@ -192,7 +192,7 @@ class AVPlayerEngine: AVPlayer {
         }
     }
     
-    override func play() {
+    override public func play() {
         // makes sure play/pause call is made on the main thread (calling on background thread has unpredictable behaviours)
         DispatchQueue.main.async {
             if self.rate == 0 {
@@ -241,7 +241,7 @@ class AVPlayerEngine: AVPlayer {
 
 extension AVPlayerEngine: AppStateObservable {
  
-    var observations: Set<NotificationObservation> {
+    public var observations: Set<NotificationObservation> {
         return [
             NotificationObservation(name: .UIApplicationWillTerminate) { [unowned self] in
                 PKLog.debug("player: \(self)\n will terminate, destroying...")

--- a/Classes/Player/PlayerController.swift
+++ b/Classes/Player/PlayerController.swift
@@ -126,12 +126,12 @@ class PlayerController: NSObject, Player, PlayerSettings {
     
     private func createPlayerWrapper(_ mediaConfig: MediaConfig) throws {
         if (mediaConfig.mediaEntry.vrData != nil) {
-            guard let vrPlayerWrapper = NSClassFromString("VRPlayerWrapper") as? VRPlayerEngine else {
+            guard let vrPlayerWrapper = NSClassFromString("PlayKitVR.VRPlayerWrapper") as? VRPlayerEngine.Type else {
                 PKLog.error("VRPlayerWrapper does not exist")
                 throw PlayerError.missingDependency.asNSError
             }
             
-            self.currentPlayer = vrPlayerWrapper
+            self.currentPlayer = vrPlayerWrapper.init(delegate: self.delegate)
         } else {
             self.currentPlayer = AVPlayerWrapper()
         }

--- a/Classes/Player/PlayerWrapper/AVPlayerWrapper.swift
+++ b/Classes/Player/PlayerWrapper/AVPlayerWrapper.swift
@@ -12,10 +12,10 @@ import Foundation
 import AVFoundation
 import AVKit
 
-class AVPlayerWrapper: NSObject, PlayerEngine {
-    var onEventBlock: ((PKEvent) -> Void)?
+open class AVPlayerWrapper: NSObject, PlayerEngine {
+    public var onEventBlock: ((PKEvent) -> Void)?
     
-    fileprivate var currentPlayer: AVPlayerEngine
+    public var currentPlayer: AVPlayerEngine
     
     /// the asset to prepare and pass to the player engine to start buffering.
     private var assetToPrepare: AVURLAsset?
@@ -100,7 +100,7 @@ class AVPlayerWrapper: NSObject, PlayerEngine {
     var shouldRefresh: Bool = false
     
     /// Load media on player
-    func loadMedia(from mediaSource: PKMediaSource?, handlerType: AssetHandler.Type) {
+    public func loadMedia(from mediaSource: PKMediaSource?, handlerType: AssetHandler.Type) {
         //todo::
         // build the asset from the selected source
         // TODO:: media sec fix no !
@@ -113,7 +113,7 @@ class AVPlayerWrapper: NSObject, PlayerEngine {
         }
     }
     
-    func prepare(_ MediaConfig: MediaConfig) throws {
+    public func prepare(_ MediaConfig: MediaConfig) throws {
         // set background thread to make sure main thread is not stuck while waiting
         DispatchQueue.global().async {
             // wait till assetToPrepare is set
@@ -133,23 +133,23 @@ class AVPlayerWrapper: NSObject, PlayerEngine {
         }
     }
     
-    func play() {
+    public func play() {
         self.currentPlayer.play()
     }
     
-    func pause() {
+    public func pause() {
         self.currentPlayer.pause()
     }
     
-    func resume() {
+    public func resume() {
         self.currentPlayer.play()
     }
     
-    func stop() {
+    public func stop() {
         self.currentPlayer.stop()
     }
     
-    func seek(to time: TimeInterval) {
+    public func seek(to time: TimeInterval) {
         self.currentPlayer.currentPosition = time
     }
     
@@ -157,7 +157,7 @@ class AVPlayerWrapper: NSObject, PlayerEngine {
         self.currentPlayer.selectTrack(trackId: trackId)
     }
     
-    func destroy() {
+    public func destroy() {
         self.currentPlayer.destroy()
         self.removeAssetRefreshObservers()
     }

--- a/Classes/Player/Protocols/Player.swift
+++ b/Classes/Player/Protocols/Player.swift
@@ -11,7 +11,7 @@
 import UIKit
 
 @objc public protocol PlayerDelegate {
-    func playerShouldPlayAd(_ player: Player) -> Bool
+    @objc optional func shouldAddPlayerViewController(_ vc: UIViewController)
 }
 
 /// `PlayerSettings` used for optional `Player` settings.

--- a/Classes/Player/VR/VRPlayerEngine.swift
+++ b/Classes/Player/VR/VRPlayerEngine.swift
@@ -9,7 +9,8 @@
 // ===================================================================================================
 
 import Foundation
+import AVFoundation
 
 public protocol VRPlayerEngine: PlayerEngine {
-
+    init(delegate: PlayerDelegate?)
 }


### PR DESCRIPTION
* `AVPlayerWrapper` is `open` now
* `AVPlayerEngine ` is `public` now
*  Fix `VRPlayerWrapper` reflection support
*  Add `shouldAddPlayerViewController` function to `PlayerDelegate` - Let the SDK user know when VR viewController is ready for attachment
* Remove `playerShouldPlayAd` function from `PlayerDelegate` - never been used