### PR TITLE
#FEM-1670

### DIFF
--- a/Classes/Player/AVPlayerEngine/AVPlayerEngine+Observation.swift
+++ b/Classes/Player/AVPlayerEngine/AVPlayerEngine+Observation.swift
@@ -36,7 +36,7 @@ extension AVPlayerEngine {
         self.isObserved = true
         // Register observers for the properties we want to display.
         for keyPath in observedKeyPaths {
-            addObserver(self, forKeyPath: keyPath, options: [.new, .initial], context: &observerContext)
+            addObserver(self, forKeyPath: keyPath, options: [.new, .initial], context: &AVPlayerEngine.observerContext)
         }
         
         NotificationCenter.default.addObserver(self, selector: #selector(self.didFailToPlayToEndTime(_:)), name: .AVPlayerItemFailedToPlayToEndTime, object: self.currentItem)
@@ -55,7 +55,7 @@ extension AVPlayerEngine {
         
         // Un-register observers
         for keyPath in observedKeyPaths {
-            removeObserver(self, forKeyPath: keyPath, context: &observerContext)
+            removeObserver(self, forKeyPath: keyPath, context: &AVPlayerEngine.observerContext)
         }
         
         NotificationCenter.default.removeObserver(self, name: .AVPlayerItemFailedToPlayToEndTime, object: nil)
@@ -107,7 +107,7 @@ extension AVPlayerEngine {
     override func observeValue(forKeyPath keyPath: String?, of object: Any?, change: [NSKeyValueChangeKey : Any]?, context: UnsafeMutableRawPointer?) {
         PKLog.debug("observeValue:: onEvent/onState")
         
-        guard context == &observerContext else {
+        guard context == &AVPlayerEngine.observerContext else {
             super.observeValue(forKeyPath: keyPath, of: object, change: change, context: context)
             return
         }

--- a/Classes/Player/AVPlayerEngine/AVPlayerEngine.swift
+++ b/Classes/Player/AVPlayerEngine/AVPlayerEngine.swift
@@ -35,7 +35,7 @@ class AVPlayerEngine: AVPlayer {
     var isFirstReady = true
     var currentState: PlayerState = PlayerState.idle
     var tracksManager = TracksManager()
-    var observerContext = 0
+    static var observerContext = 0
     
     var onEventBlock: ((PKEvent) -> Void)?
     


### PR DESCRIPTION
having the kvo context as a variable causes a warning by the swift 4 runtime about multi access to the same resource, this is caused because swift 4 uses a different mechanism for variable access.
using static variable instead allows this because it is a persistent unique pointer that won't be change and that is why it can be used safely as a context for KVO.