### PR TITLE
Duration nan protection

### DIFF
--- a/Classes/Player/AVPlayerEngine/AVPlayerEngine.swift
+++ b/Classes/Player/AVPlayerEngine/AVPlayerEngine.swift
@@ -113,7 +113,8 @@ class AVPlayerEngine: AVPlayer {
         }
         
         PKLog.trace("get duration: \(result)")
-        return result
+        // in some rare cases duration can be nan, in that case we will return 0.
+        return result.isNaN ? 0.0 : result
     }
     
     var isPlaying: Bool {


### PR DESCRIPTION
### Description of the Changes

In some cases duration is nan and we don't want to return this value, can cause issues.
So in this cases 0 will be returned instead.

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [X] test are passing in local environment 
- [X] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated