### PR TITLE
#FEM-1826

### DIFF
--- a/Classes/Player/AVPlayerEngine/AVPlayerEngine+AssetLoading.swift
+++ b/Classes/Player/AVPlayerEngine/AVPlayerEngine+AssetLoading.swift
@@ -18,6 +18,7 @@ extension AVPlayerEngine {
         self.lastTimebaseRate = 0
         // When changing media (loading new asset) we want to reset isFirstReady in order to receive `CanPlay` & `LoadedMetadata` accuratly.
         self.isFirstReady = true
+        self.lastIndicatedBitrate = 0
         super.replaceCurrentItem(with: item)
     }
     

--- a/Classes/Player/AVPlayerEngine/AVPlayerEngine.swift
+++ b/Classes/Player/AVPlayerEngine/AVPlayerEngine.swift
@@ -29,7 +29,8 @@ public class AVPlayerEngine: AVPlayer {
 
     /// Keeps reference on the last timebase rate in order to post events accuratly.
     var lastTimebaseRate: Float64 = 0
-    var lastBitrate: Double = 0
+    /// The last indicated bitrate observed can tell what is the last video track bitrate that was used.
+    var lastIndicatedBitrate: Double = 0
     var isObserved: Bool = false
     /// Indicates if player item was changed to state: `readyToPlay` at least once.
     /// Used to post `CanPlay` event once on first `readyToPlay`.


### PR DESCRIPTION
### Description of the Changes

* Fix an issue where more than one player is active notification from avplayer are received twice.
Now filters the calls to when notification object is the current player item.
* Fix an issue where VideoTrackSelected event would be sent more than once for the same indicated bitrate.

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment 
- [X] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated