### PR TITLE
#FEM-1867 widevine classic wrong media format

### DIFF
--- a/Classes/Player/Media/PKMediaSource.swift
+++ b/Classes/Player/Media/PKMediaSource.swift
@@ -32,7 +32,7 @@ import SwiftyJSON
             }
         }
         
-        static func mediaFormat(byfileExtension ext:String) -> MediaFormat{
+        static func mediaFormat(byfileExtension ext: String) -> MediaFormat {
             switch ext.lowercased() {
             case "m3u8": return .hls
             case "wvm": return .wvm
@@ -83,7 +83,7 @@ import SwiftyJSON
         self.id = id
         self.contentUrl = contentUrl
         self.drmData = drmData
-        self.mediaFormat = mediaFormat
+        self.mediaFormat = mediaFormat == .unknown ? MediaFormat.mediaFormat(byfileExtension: contentUrl?.pathExtension ?? "") : mediaFormat
     }
     
     @objc public init(json: Any) {


### PR DESCRIPTION
### Description of the Changes

* fixed issue where media format was constructed without the needed format type, now if no format was given tries to handle using the provided url.

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment 
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated