### PR TITLE
#FEM-1941

### DIFF
--- a/Classes/Backend/OVP/Services/OVPBaseEntryService.swift
+++ b/Classes/Backend/OVP/Services/OVPBaseEntryService.swift
@@ -19,10 +19,9 @@ class OVPBaseEntryService {
         
         if let request: KalturaRequestBuilder = KalturaRequestBuilder(url: baseURL, service: "baseEntry", action: "list") {
             let responseProfile = ["fields": "mediaType,dataUrl,id,name,duration,msDuration,flavorParamsIds,tags", "type": 1] as [String: Any]
-            let filter = ["redirectFromEntryId":entryID]
             request.setBody(key: "ks", value: JSON(ks))
-            .setBody(key: "responseProfile", value: JSON(responseProfile))
-            .setBody(key: "filter", value: JSON(filter))
+                .setBody(key: "responseProfile", value: JSON(responseProfile))
+                .setBody(key: "filter:redirectFromEntryId", value: JSON(entryID))
             return request
         } else {
             return nil

--- a/Classes/Providers/OVP/OVPMediaProvider.swift
+++ b/Classes/Providers/OVP/OVPMediaProvider.swift
@@ -262,7 +262,7 @@ import KalturaNetKit
                             }
                         }
 
-                        let playURL: URL? = self.playbackURL(loadInfo: loadInfo, source: source, ks: ksForURL)
+                        let playURL: URL? = self.playbackURL(entryId: entry.id, loadInfo: loadInfo, source: source, ks: ksForURL)
                         guard let url = playURL else {
                             PKLog.error("failed to create play url from source, discarding source:\(entry.id),\(source.deliveryProfileId), \(source.format)")
                             return
@@ -347,7 +347,7 @@ import KalturaNetKit
     }
     
     // building the url with the SourceBuilder class
-    private func playbackURL(loadInfo: LoaderInfo, source: OVPSource, ks: String?) -> URL? {
+    private func playbackURL(entryId: String, loadInfo: LoaderInfo, source: OVPSource, ks: String?) -> URL? {
         
         let formatType = FormatsHelper.getMediaFormat(format: source.format, hasDrm: source.drm != nil)
         var playURL: URL? = nil
@@ -357,7 +357,7 @@ import KalturaNetKit
             let sourceBuilder: SourceBuilder = SourceBuilder()
                 .set(baseURL: loadInfo.sessionProvider.serverURL)
                 .set(format: source.format)
-                .set(entryId: loadInfo.entryId)
+                .set(entryId: entryId)
                 .set(uiconfId: loadInfo.uiconfId?.int64Value)
                 .set(flavors: source.flavors)
                 .set(partnerId: loadInfo.sessionProvider.partnerId)


### PR DESCRIPTION
### Description of the Changes

* Fixed issue with ovp provider when trying to get live entry that redirects to vod content the entry id wasn't set correctly, used the same entry from the request we had instead of the id from the response.

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment 
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated