### PR TITLE
Add KalturaUDRMLicenseRequestAdapter

### DIFF
--- a/Classes/Network/KalturaUDRMLicenseRequestAdapter.swift
+++ b/Classes/Network/KalturaUDRMLicenseRequestAdapter.swift
@@ -1,0 +1,39 @@
+// ===================================================================================================
+// Copyright (C) 2018 Kaltura Inc.
+//
+// Licensed under the AGPLv3 license, unless a different license for a 
+// particular library is specified in the applicable library path.
+//
+// You may obtain a copy of the License at
+// https://www.gnu.org/licenses/agpl-3.0.html
+// ===================================================================================================
+
+import Foundation
+
+
+@objc public class KalturaUDRMLicenseRequestAdapter: NSObject, PKRequestParamsAdapter {
+    
+    private var applicationName: String?
+    
+    /// Installs a new kaltura request adapter on the provided player with custom application name.
+    ///
+    /// - Parameters:
+    ///   - player: The player you want to use with the request adapter
+    ///   - applicationName: the application name, if `nil` will use the bundle identifier.
+    @objc public static func install(in player: Player, withAppName appName: String) {
+        let requestAdapter = KalturaUDRMLicenseRequestAdapter()
+        requestAdapter.applicationName = appName
+        player.settings.licenseRequestAdapter = requestAdapter
+    }
+    
+    /// Updates the request adapter with info from the player
+    @objc public func updateRequestAdapter(with player: Player) {
+    }
+    
+    /// Adapts the request params
+    @objc public func adapt(requestParams: PKRequestParams) -> PKRequestParams {
+        var headers = requestParams.headers ?? [:]
+        headers["Referrer"] = applicationName
+        return PKRequestParams(url: requestParams.url, headers: headers)
+    }
+}

--- a/Classes/Player/Media/AssetLoaderDelegate.swift
+++ b/Classes/Player/Media/AssetLoaderDelegate.swift
@@ -116,8 +116,19 @@ class AssetLoaderDelegate: NSObject {
         
         guard let licenseUri = drmData?.licenseUri else { return }
         
-        var request = URLRequest(url: licenseUri)
-        request.setValue("application/octet-stream", forHTTPHeaderField: "Content-Type")
+        var requestParams = PKRequestParams(url: licenseUri, headers: ["Content-Type": "application/octet-stream"])
+        
+        if let adapter = drmData?.requestAdapter {
+            requestParams = adapter.adapt(requestParams: requestParams)
+        }
+        
+        var request = URLRequest(url: requestParams.url)
+        if let headers = requestParams.headers {
+            for (header, value) in headers {
+                request.setValue(value, forHTTPHeaderField: header)
+            }
+        }
+        
         request.httpBody = spcData.base64EncodedData()
         request.httpMethod = "POST"
         

--- a/Classes/Player/Media/PKMediaEntry.swift
+++ b/Classes/Player/Media/PKMediaEntry.swift
@@ -98,6 +98,7 @@ import SwiftyJSON
     
     var licenseUri: URL?
     var scheme: Scheme
+    var requestAdapter: PKRequestParamsAdapter?
     
     init(licenseUri: String?, scheme: Scheme) {
         if let url = licenseUri {

--- a/Classes/Player/PKPlayerSettings.swift
+++ b/Classes/Player/PKPlayerSettings.swift
@@ -76,13 +76,15 @@ enum PlayerSettingsType {
     @objc public var network = PKNetworkSettings()
     @objc public var trackSelection = PKTrackSelectionSettings()
     
-    @objc public var contentRequestAdapter: PKRequestParamsAdapter? = KalturaPlaybackRequestAdapter()
+    @objc public var contentRequestAdapter: PKRequestParamsAdapter?
+    @objc public var licenseRequestAdapter: PKRequestParamsAdapter?
     
     @objc public func createCopy() -> PKPlayerSettings {
         let copy = PKPlayerSettings()
         copy.network = self.network
         copy.trackSelection = self.trackSelection
         copy.contentRequestAdapter = self.contentRequestAdapter
+        copy.licenseRequestAdapter = self.licenseRequestAdapter
         return copy
     }
 }

--- a/Classes/Player/PlayerController.swift
+++ b/Classes/Player/PlayerController.swift
@@ -293,6 +293,12 @@ fileprivate extension PlayerController {
             // configure media source with the adapter
             mediaSource.contentRequestAdapter = adapter
         }
+        
+        if let adapter = self.settings.licenseRequestAdapter, let drmData = mediaSource.drmData {
+            for p in drmData {
+                p.requestAdapter = adapter
+            }
+        }
     }
 }
 


### PR DESCRIPTION
After calling loadPlayer(), the application can now call:

	KalturaUDRMLicenseRequestAdapter.install(in: player, withAppName: "myapp.com")

This will set the referrer on license requests.
