### PR TITLE
FEM-2067 Fix for currentPosition returning a negative value.

### DIFF
--- a/Classes/Player/AVPlayerEngine/AVPlayerEngine.swift
+++ b/Classes/Player/AVPlayerEngine/AVPlayerEngine.swift
@@ -67,9 +67,17 @@ public class AVPlayerEngine: AVPlayer {
     public var currentPosition: TimeInterval {
         get {
             let position = self.currentTime() - self.rangeStart
+            
             PKLog.trace("get currentPosition: \(position)")
-            let time = CMTimeGetSeconds(position)
-            // time could be NaN in some rare cases make sure we don't return NaN and return 0 otherwise.
+            var time = CMTimeGetSeconds(position)
+            
+            // In some cases the video will start playing with negative current time.
+            // self.currentTime() returns a large negative value
+            if time < 0.0 {
+                time = 0
+            }
+            
+            // Time could be NaN in some rare cases make sure we don't return NaN and return 0 otherwise.
             return time.isNaN ? 0 : time
         }
         set {


### PR DESCRIPTION
### Description of the Changes

CurrentPosition of the player returns a negative value when the player hasn't started and on live streaming when seeking all the way back.
In no case it should be negative therefore, in such case, returning 0.
