### PR TITLE
Fix for Issues for QA report iteration #1

### DIFF
--- a/Plugins/Youbora/PKYouboraAdsAdapter.swift
+++ b/Plugins/Youbora/PKYouboraAdsAdapter.swift
@@ -127,6 +127,7 @@ extension PKYouboraAdsAdapter {
             AdEvent.adStartedBuffering,
             AdEvent.adPlaybackReady,
             AdEvent.adsRequested,
+            AdEvent.adClicked,
             AdEvent.adDidRequestContentResume
         ]
     }

--- a/Plugins/Youbora/PKYouboraPlayerAdapter.swift
+++ b/Plugins/Youbora/PKYouboraPlayerAdapter.swift
@@ -203,10 +203,12 @@ extension PKYouboraPlayerAdapter {
             case let e where e.self == PlayerEvent.playing:
                 messageBus.addObserver(self, events: [e.self]) { [weak self] event in
                     guard let strongSelf = self else { return }
+                    strongSelf.fireJoin()
+                    strongSelf.fireBufferEnd()
                     if strongSelf.isFirstPlay {
                         strongSelf.isFirstPlay = false
-                        strongSelf.fireJoin()
-                        strongSelf.fireBufferEnd()
+                        //strongSelf.fireJoin()
+                        //strongSelf.fireBufferEnd()
                     } else {
                         strongSelf.fireResume()
                     }
@@ -256,7 +258,7 @@ extension PKYouboraPlayerAdapter {
                 messageBus.addObserver(self, events: [e.self]) { [weak self] event in
                     guard let strongSelf = self else { return }
                     if let error = event.error, error.code == PKErrorCode.playerItemFailed {
-                        strongSelf.fireError(withMessage: error.localizedDescription, code: "\(error.code)", andMetadata: error.description)
+                        strongSelf.fireFatalError(withMessage: error.localizedDescription, code: "\(error.code)", andMetadata: error.description)
                     }
                 }
             case let e where e.self == PlayerEvent.durationChanged:

--- a/Plugins/Youbora/YouboraPlugin.swift
+++ b/Plugins/Youbora/YouboraPlugin.swift
@@ -176,8 +176,8 @@ public class YouboraPlugin: BasePlugin, AppStateObservable {
     }
     
     private func endedHandler() {
-        youboraNPAWPlugin?.adapter?.fireStop()
         youboraNPAWPlugin?.adsAdapter?.fireStop()
+        youboraNPAWPlugin?.adapter?.fireStop()
     }
     
     private func addCustomProperties(toOptions options: inout [String: Any]) {


### PR DESCRIPTION
This pull request fixes issues from QA report:

24,73,115,130,234

Short description of the changes:

- Ad adapter was not listening to AdClick event, so it was never fired
- fireJoin and fireBufferEnd are now fired regardless if it's a first play or not
- Now all errors are fatal, that means that any error will send /stop with it
- Small change to avoid a potential problem for not stoping adsAdapter before adapter