### PR TITLE
FEM-2219: Add and handle assetReferenceType as a parameter in PhoenixMediaProvider

### DIFF
--- a/Classes/Backend/OTT/Model/OTTMediaAsset.swift
+++ b/Classes/Backend/OTT/Model/OTTMediaAsset.swift
@@ -8,19 +8,22 @@
 import Foundation
 import SwiftyJSON
 
+
+fileprivate let idKey = "id"
+fileprivate let typeKey = "type"
+fileprivate let nameKey = "name"
+fileprivate let mediaFilesKey = "mediaFiles"
+fileprivate let metasKey = "metas"
+
 public class OTTMediaAsset: OTTBaseObject {
+    // This class is for both KalturaMediaAsset and KalturaProgramAsset, because
+    // the fields we use are common between them.
     
     var id: Int?
     var type: Int?
     var name: String?
     var mediaFiles: [OTTMediaFile] = []
     var metas: Dictionary<String, OTTBaseObject> = Dictionary()
-    
-    let idKey = "id"
-    let typeKey = "type"
-    let nameKey = "name"
-    let mediaFilesKey = "mediaFiles"
-    let metasKey = "metas"
     
     public required init?(json: Any) {
         let jsonObj: JSON = JSON(json)

--- a/Classes/Backend/OTT/Parsers/OTTObjectMapper.swift
+++ b/Classes/Backend/OTT/Parsers/OTTObjectMapper.swift
@@ -27,7 +27,7 @@ class OTTObjectMapper: NSObject {
                 return OTTPlaybackSource.self
             case "KalturaPlaybackContext":
                 return OTTPlaybackContext.self
-            case "KalturaMediaAsset":
+            case "KalturaMediaAsset", "KalturaProgramAsset":
                 return OTTMediaAsset.self
             case "KalturaMediaFile":
                 return OTTMediaFile.self

--- a/Classes/Backend/OTT/Services/OTTAssetService.swift
+++ b/Classes/Backend/OTT/Services/OTTAssetService.swift
@@ -14,7 +14,7 @@ import KalturaNetKit
 
 class OTTAssetService {
 
-    internal static func getPlaybackContext(baseURL: String, ks: String, assetId: String, type: AssetObjectType, playbackContextOptions: PlaybackContextOptions) -> KalturaRequestBuilder? {
+    internal static func getPlaybackContext(baseURL: String, ks: String, assetId: String, type: AssetTypeAPI, playbackContextOptions: PlaybackContextOptions) -> KalturaRequestBuilder? {
 
         if let request: KalturaRequestBuilder = KalturaRequestBuilder(url: baseURL, service: "asset", action: "getPlaybackContext") {
             request
@@ -28,14 +28,13 @@ class OTTAssetService {
         }
     }
     
-    internal static func getMetaData(baseURL: String, ks: String, assetId: String, type: AssetObjectType) -> KalturaRequestBuilder? {
+    internal static func getMetaData(baseURL: String, ks: String, assetId: String, refType: AssetReferenceTypeAPI) -> KalturaRequestBuilder? {
         
         if let request: KalturaRequestBuilder = KalturaRequestBuilder(url: baseURL, service: "asset", action: "get") {
             request
                 .setBody(key: "ks", value: JSON(ks))
                 .setBody(key: "id", value: JSON(assetId))
-                .setBody(key: "assetReferenceType", value: JSON(type.asString))
-                .setBody(key: "type", value: JSON(type.asString))
+                .setBody(key: "assetReferenceType", value: JSON(refType.asString))
             return request
         }
         
@@ -45,7 +44,7 @@ class OTTAssetService {
 
 struct PlaybackContextOptions {
 
-    var playbackContextType: PlaybackType
+    var playbackContextType: PlaybackTypeAPI
     var protocls: [String]
     var assetFileIds: [String]?
     var referrer: String?

--- a/Classes/Backend/OTT/Services/PhoenixAPIDefines.swift
+++ b/Classes/Backend/OTT/Services/PhoenixAPIDefines.swift
@@ -11,28 +11,36 @@
 import Foundation
 
 
-enum AssetObjectType: Int {
+enum AssetTypeAPI: Int {
     case media
     case epg
-    case unknown
     
     var asString: String {
         switch self {
         case .media: return "media"
         case .epg: return "epg"
-        case .unknown: return ""
         }
     }
 }
 
+enum AssetReferenceTypeAPI: Int {
+    case media, epgInternal, epgExternal
+    
+    var asString: String {
+        switch self {
+        case .media: return "media"
+        case .epgInternal: return "epg_internal"
+        case .epgExternal: return "epg_external"
+        }
+    }
+}
 
-enum PlaybackType: Int {
+enum PlaybackTypeAPI: Int {
     
     case trailer
     case catchup
     case startOver
     case playback
-    case unknown
     
     var asString: String {
         switch self {
@@ -40,7 +48,6 @@ enum PlaybackType: Int {
         case .catchup: return "CATCHUP"
         case .startOver: return "START_OVER"
         case .playback: return "PLAYBACK"
-        case .unknown: return ""
         }
     }
 }


### PR DESCRIPTION
- `asset.get` was using the value of `assetType` as input to `assetReferenceType`, which is wrong: it happens to work when `assetType` is `media`. But when it's `epg` the value of `assetReferenceType` has to be either `epg_internal` or `epg_external`. Added it as a provider property.
- The response for `asset.get` when the type is `epg*` is `KalturaProgramAsset`. This type wasn't handled. Changed so that it's handled by `OTTMediaAsset`, which also handles `KalturaMediaAsset`.