### PR TITLE
Only enable TimeObserver after a PlayerEngine is created

### DIFF
--- a/Classes/Managers/TimeObserver.swift
+++ b/Classes/Managers/TimeObserver.swift
@@ -102,6 +102,13 @@ class TimeObserver: TimeMonitor {
     /// The timer source that will be used to fire the events.
     var dispatchTimer: DispatchSourceTimer?
     
+    // Should the TimeObserver be active?
+    var enabled = false {
+        didSet {
+            startStopTimer()
+        }
+    }
+    
     /// all boundary observations, mapped by time in [millis: observation]
     var boundaryObservations = [Int64: [BoundaryObservation]]() {
         didSet {
@@ -251,6 +258,11 @@ class TimeObserver: TimeMonitor {
     /************************************************************/
     
     func startTimer() {
+        
+        if !enabled {
+            return
+        }
+        
         // reset the timer
         if let dispatchTimer = self.dispatchTimer {
             dispatchTimer.cancel()

--- a/Classes/Player/PlayerController.swift
+++ b/Classes/Player/PlayerController.swift
@@ -200,6 +200,7 @@ class PlayerController: NSObject, Player {
             currentPlayer.settings = self.settings
         }
         
+        // If we just created a player, enable the TimeObserver
         if isCreated {
             timeObserver.enabled = true
         }

--- a/Classes/Player/PlayerController.swift
+++ b/Classes/Player/PlayerController.swift
@@ -21,8 +21,10 @@ class PlayerController: NSObject, Player {
     weak var delegate: PlayerDelegate?
     
     fileprivate var currentPlayer: PlayerEngine = DefaultPlayerWrapper() {
+        // Initialize the currentPlayer to DefaultPlayerWrapper, which does nothing except printing warnings.
         didSet {
-            timeObserver.enabled = true
+            // When set to a real player, enable the observer. 
+            timeObserver.enabled = !(currentPlayer is DefaultPlayerWrapper)
         }
     }
     

--- a/Classes/Player/PlayerController.swift
+++ b/Classes/Player/PlayerController.swift
@@ -199,6 +199,11 @@ class PlayerController: NSObject, Player {
         if let currentPlayer = self.currentPlayer as? AVPlayerWrapper {
             currentPlayer.settings = self.settings
         }
+        
+        if isCreated {
+            timeObserver.enabled = true
+        }
+        
         return isCreated
     }
     

--- a/Classes/Player/PlayerController.swift
+++ b/Classes/Player/PlayerController.swift
@@ -20,7 +20,11 @@ class PlayerController: NSObject, Player {
     
     weak var delegate: PlayerDelegate?
     
-    fileprivate var currentPlayer: PlayerEngine
+    fileprivate var currentPlayer: PlayerEngine = DefaultPlayerWrapper() {
+        didSet {
+            timeObserver.enabled = true
+        }
+    }
     
     /// Current selected media source
     fileprivate var selectedSource: PKMediaSource?
@@ -109,11 +113,7 @@ class PlayerController: NSObject, Player {
     // MARK: - Initialization
     /************************************************************/
     
-    public override init() {
-        // Since currentPlayer is PlayerEngine! 
-        // Dafault Wrapper creation for safety
-        self.currentPlayer = DefaultPlayerWrapper()
-        
+    public override init() {        
         super.init()
         self.timeObserver = TimeObserver(timeProvider: self)
         self.currentPlayer.onEventBlock = { [weak self] event in
@@ -198,11 +198,6 @@ class PlayerController: NSObject, Player {
         
         if let currentPlayer = self.currentPlayer as? AVPlayerWrapper {
             currentPlayer.settings = self.settings
-        }
-        
-        // If we just created a player, enable the TimeObserver
-        if isCreated {
-            timeObserver.enabled = true
         }
         
         return isCreated


### PR DESCRIPTION
TimeObserver now has an `enabled` property, defaults to false. When set to true (by `PlayerController`) it starts the timer (if required).
