### PR TITLE
FEM-2248 Finish Bookmark sent twice

### DIFF
--- a/Plugins/Phoenix/BaseOTTAnalyticsPlugin.swift
+++ b/Plugins/Phoenix/BaseOTTAnalyticsPlugin.swift
@@ -217,13 +217,5 @@ extension BaseOTTAnalyticsPlugin {
         
         let progress = Float(player.currentTime) / Float(player.duration)
         PKLog.debug("Progress is \(progress)")
-        
-        if progress > 0.98 {
-            self.sendAnalyticsEvent(ofType: .finish)
-        }
     }
 }
-
-
-
-


### PR DESCRIPTION
 Should only be sent upon PlayerEvent.ended.
