### PR TITLE
FEM-2249 Hit Bookmark should be sent only after playback starts.

### DIFF
--- a/Plugins/Phoenix/BaseOTTAnalyticsPlugin.swift
+++ b/Plugins/Phoenix/BaseOTTAnalyticsPlugin.swift
@@ -194,9 +194,6 @@ extension BaseOTTAnalyticsPlugin {
             self.timer = nil
         }
         
-        // media hit should fire on every time we start the timer.
-        self.sendProgressEvent()
-        
         self.timer = PKTimer.every(self.interval) { [weak self] _ in
             PKLog.debug("timerHit")
             self?.sendProgressEvent()


### PR DESCRIPTION
Hit Bookmark should be sent only after playback starts, every 30 sec.
