### PR TITLE
FEM-2278 Crash upon going to the background in some cases.

### DIFF
--- a/Classes/Player/AVPlayerEngine/AVPlayerEngine.swift
+++ b/Classes/Player/AVPlayerEngine/AVPlayerEngine.swift
@@ -274,22 +274,22 @@ extension AVPlayerEngine: AppStateObservable {
     public var observations: Set<NotificationObservation> {
         return [
             NotificationObservation(name: .UIApplicationWillTerminate, onObserve: { [weak self] in
-                guard let `self` = self else { return }
+                guard let strongSelf = self else { return }
                 
-                PKLog.debug("player: \(self)\n Will terminate, destroying...")
-                self.destroy()
+                PKLog.debug("player: \(strongSelf)\n Will terminate, destroying...")
+                strongSelf.destroy()
             }),
             NotificationObservation(name: .UIApplicationDidEnterBackground, onObserve: { [weak self] in
-                guard let `self` = self else { return }
+                guard let strongSelf = self else { return }
                 
-                PKLog.debug("player: \(self)\n Did enter background, finishing up...")
-                self.startBackgroundTask()
+                PKLog.debug("player: \(strongSelf)\n Did enter background, finishing up...")
+                strongSelf.startBackgroundTask()
             }),
             NotificationObservation(name: .UIApplicationWillEnterForeground, onObserve: { [weak self] in
-                guard let `self` = self else { return }
+                guard let strongSelf = self else { return }
                 
-                PKLog.debug("player: \(self)\n Will enter foreground...")
-                self.endBackgroundTask()
+                PKLog.debug("player: \(strongSelf)\n Will enter foreground...")
+                strongSelf.endBackgroundTask()
             })
         ]
     }
@@ -297,10 +297,10 @@ extension AVPlayerEngine: AppStateObservable {
     func startBackgroundTask() {
         
         self.backgroundTaskIdentifier = UIApplication.shared.beginBackgroundTask(withName: "AVPlayerEngineBackgroundTask", expirationHandler: { [weak self] in
-            guard let `self` = self else { return }
+            guard let strongSelf = self else { return }
             
-            PKLog.debug("player: \(self)\n Reached the expirationHandler")
-            self.endBackgroundTask()
+            PKLog.debug("player: \(strongSelf)\n Reached the expirationHandler")
+            strongSelf.endBackgroundTask()
         })
 
         if self.backgroundTaskIdentifier == UIBackgroundTaskInvalid {

--- a/Classes/Player/AVPlayerEngine/AVPlayerEngine.swift
+++ b/Classes/Player/AVPlayerEngine/AVPlayerEngine.swift
@@ -17,7 +17,8 @@ import CoreMedia
 /// It provides the interface to control the player’s behavior such as its ability to play, pause, and seek to various points in the timeline.
 public class AVPlayerEngine: AVPlayer {
     
-    var backgroundTaskIdentifier: UIBackgroundTaskIdentifier = UIBackgroundTaskInvalid
+    private var backgroundTaskIdentifier: UIBackgroundTaskIdentifier = UIBackgroundTaskInvalid
+    private var backgroundTimer: Timer?
     
     // MARK: Player Properties
     
@@ -272,33 +273,49 @@ extension AVPlayerEngine: AppStateObservable {
  
     public var observations: Set<NotificationObservation> {
         return [
-            NotificationObservation(name: .UIApplicationWillTerminate) { [unowned self] in
-                PKLog.debug("player: \(self)\n will terminate, destroying...")
+            NotificationObservation(name: .UIApplicationWillTerminate, onObserve: { [weak self] in
+                guard let `self` = self else { return }
+                
+                PKLog.debug("player: \(self)\n Will terminate, destroying...")
                 self.destroy()
-            },
-            NotificationObservation(name: .UIApplicationDidEnterBackground) { [unowned self] in
-                PKLog.debug("player: \(self)\n did enter background, finishing up...")
+            }),
+            NotificationObservation(name: .UIApplicationDidEnterBackground, onObserve: { [weak self] in
+                guard let `self` = self else { return }
+                
+                PKLog.debug("player: \(self)\n Did enter background, finishing up...")
                 self.startBackgroundTask()
-            }
+            }),
+            NotificationObservation(name: .UIApplicationWillEnterForeground, onObserve: { [weak self] in
+                guard let `self` = self else { return }
+                
+                PKLog.debug("player: \(self)\n Will enter foreground...")
+                self.endBackgroundTask()
+            })
         ]
     }
     
     func startBackgroundTask() {
-        self.backgroundTaskIdentifier = UIApplication.shared.beginBackgroundTask(withName: "AVPlayerEngineBackgroundTask") { [unowned self] in
+        
+        self.backgroundTaskIdentifier = UIApplication.shared.beginBackgroundTask(withName: "AVPlayerEngineBackgroundTask", expirationHandler: { [weak self] in
+            guard let `self` = self else { return }
+            
+            PKLog.debug("player: \(self)\n Reached the expirationHandler")
             self.endBackgroundTask()
-        }
+        })
 
         if self.backgroundTaskIdentifier == UIBackgroundTaskInvalid {
             PKLog.debug("backgroundTaskIdentifier is invalid, can't create backgroundTask.")
         } else {
             PKLog.debug("backgroundTaskIdentifier:\(String(describing: self.backgroundTaskIdentifier)))")
-            Timer.scheduledTimer(timeInterval: 10, target: self, selector: #selector(endBackgroundTask), userInfo: nil, repeats: false)
+            self.backgroundTimer = Timer.scheduledTimer(timeInterval: 10, target: self, selector: #selector(endBackgroundTask), userInfo: nil, repeats: false)
         }
     }
 
     @objc func endBackgroundTask() {
         if self.backgroundTaskIdentifier != UIBackgroundTaskInvalid {
-            PKLog.debug("player: \(self)\n in background, ending the background task...(backgroundTaskIdentifier:\(String(describing: backgroundTaskIdentifier)))")
+            PKLog.debug("player: \(self)\n Ending the background task...(backgroundTaskIdentifier:\(String(describing: backgroundTaskIdentifier)))")
+            self.backgroundTimer?.invalidate()
+            self.backgroundTimer = nil
             UIApplication.shared.endBackgroundTask(backgroundTaskIdentifier)
             self.backgroundTaskIdentifier = UIBackgroundTaskInvalid
         }


### PR DESCRIPTION
### Description of the Changes

Removed unowned self in callback function, to prevent a crash when the player was deallocated.
Improved code when returning to foreground, before the timer has been fired, to end the background task.
Improved code invalidated the timer when arriving from the expirationHandler, to prevent firing the timer.
