### PR TITLE
FEM-2258: Add `pluginVersion` to `PKPlugin` protocol

### DIFF
--- a/Classes/Managers/PlayKitManager.swift
+++ b/Classes/Managers/PlayKitManager.swift
@@ -50,10 +50,21 @@ import UIKit
     }
     
     @objc public func registerPlugin(_ pluginClass: BasePlugin.Type) {
+        
+        PKLog.info("Registering plugin \(pluginClass.pluginName)/\(pluginClass.pluginVersion)")
+        
         if let pluginWarmUp = pluginClass as? PKPluginWarmUp.Type {
             pluginWarmUp.warmUp()
         }
         pluginRegistry[pluginClass.pluginName] = pluginClass
+    }
+    
+    @objc public func registeredPlugins() -> [String: String] {
+        var dict = [String: String]()
+        for (name, type) in pluginRegistry {
+            dict[name] = type.pluginVersion
+        }
+        return dict
     }
     
     func createPlugin(name: String, player: Player, pluginConfig: Any?, messageBus: MessageBus) throws -> PKPlugin {

--- a/Classes/Plugins/BasePlugin.swift
+++ b/Classes/Plugins/BasePlugin.swift
@@ -15,7 +15,14 @@ import Foundation
     
     /// abstract implementation subclasses will have names
     @objc open class var pluginName: String {
-        fatalError("abstract property should be overriden in subclass")
+        fatalError("abstract property must be overriden in subclass")
+    }
+    
+    @objc open class var pluginVersion: String {
+        guard let version = Bundle(for: self).object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String else {
+            return "?.?.?"
+        }
+        return version
     }
 
     @objc public weak var player: Player?

--- a/Classes/Plugins/PKPlugin.swift
+++ b/Classes/Plugins/PKPlugin.swift
@@ -16,6 +16,24 @@ import AVFoundation
     /// The plugin name.
     static var pluginName: String { get }
 
+    /**
+     The plugin version. The default (implemented in BasePlugin) is the plugin's bundle `CFBundleShortVersionString`:
+        `Bundle(for: pluginClass).object(forInfoDictionaryKey: "CFBundleShortVersionString")`
+     Override this function to provide a version from a different source.
+
+     Example for overriding:
+     ```
+         @objc override public class var pluginVersion: String {
+             return "1.2.3"
+         }
+     ```
+     
+     If `CFBundleShortVersionString` wasn't found (or is not a string), and no alternative implementation is 
+     provided, the string "?.?.?" is used.
+     
+    */
+    static var pluginVersion: String { get }
+
     /// The player associated with the plugin
     weak var player: Player? { get }
     /// The messageBus associated with the plugin


### PR DESCRIPTION
The default implementation uses the version from info.plist, which is typically generated by Cocoapods.
