### PR TITLE
FEM-2340 Removed calling the PKEvent namespace, to prevent leak.

### DIFF
--- a/Classes/Player/PlayerWrapper/AVPlayerWrapper.swift
+++ b/Classes/Player/PlayerWrapper/AVPlayerWrapper.swift
@@ -125,7 +125,7 @@ open class AVPlayerWrapper: NSObject, PlayerEngine {
         super.init()
         
         self.currentPlayer.onEventBlock = { [weak self] event in
-            PKLog.verbose("postEvent:: \(event.namespace)")
+            PKLog.verbose("postEvent:: \(event)")
             self?.onEventBlock?(event)
         }
         self.onEventBlock = nil


### PR DESCRIPTION
### Description of the Changes

Removed calling the PKEvent namespace, to prevent leak.
