### PR TITLE
Expose PK Playback Info To Objective-C

### DIFF
--- a/Classes/Events/EventsPayloads/PKPlaybackInfo.swift
+++ b/Classes/Events/EventsPayloads/PKPlaybackInfo.swift
@@ -15,11 +15,11 @@ import AVFoundation
 @objc public class PKPlaybackInfo: NSObject {
     
     /// The actual bitrate of the playback.
-    public let bitrate: Double
+    @objc public let bitrate: Double
     /// The selected track indicated bitrate.
-    public let indicatedBitrate: Double
+    @objc public let indicatedBitrate: Double
     /// The throughput of the playback (download speed)
-    public let observedBitrate: Double
+    @objc public let observedBitrate: Double
     
     init(bitrate: Double, indicatedBitrate: Double, observedBitrate: Double) {
         self.bitrate = bitrate


### PR DESCRIPTION
### Description of the Changes

Hey Kaltura team! I'm working with the MotorTrend/Discovery team, and we access much of Kaltura Playkit from Objective-C. We use PKPlaybackInfo for our analytics tracking.

Previously, our work-around for not being able to access these properties from Objective-C was to create a Swift wrapper that consumes PKPlaybackInfo and then exposes its properties to Objective-C. Obviously that's not very elegant, so I thought I would take the time to suggest this change.

I don't believe it breaks anything. It just exposes some properties we need.

### CheckLists

- [*] changes have been done against master branch, and PR does not conflict

- [*] new unit / functional tests have been added (whenever applicable)
    Not necessary here since we are merely exposing a property.

- [*] test are passing in local environment 
   No changes were made that affect any tests.

- [*] Travis tests are passing (or test results are not worse than on master branch :))
   No changes were made that affect any tests.

- [*] Docs have been updated
   I wouldn't consider it necessary for this PR, but if you'd like I could mention it somewhere.