### PR TITLE
Support Dropped Frames Metric

### DIFF
--- a/Classes/Events/EventsPayloads/PKPlaybackInfo.swift
+++ b/Classes/Events/EventsPayloads/PKPlaybackInfo.swift
@@ -20,11 +20,17 @@ import AVFoundation
     public let indicatedBitrate: Double
     /// The throughput of the playback (download speed)
     public let observedBitrate: Double
+    /// The total number of dropped frames during playback
+    @objc public let numberOfDroppedVideoFrames: Int    
     
-    init(bitrate: Double, indicatedBitrate: Double, observedBitrate: Double) {
+    init(bitrate: Double, 
+         indicatedBitrate: Double, 
+         observedBitrate: Double,
+         numberOfDroppedVideoFrames: Int) {
         self.bitrate = bitrate
         self.indicatedBitrate = indicatedBitrate
         self.observedBitrate = observedBitrate
+        self.numberOfDroppedVideoFrames = numberOfDroppedVideoFrames
     }
     
     convenience init(logEvent: AVPlayerItemAccessLogEvent) {
@@ -38,6 +44,10 @@ import AVFoundation
         }
         let indicatedBitrate = logEvent.indicatedBitrate
         let observedBitrate = logEvent.observedBitrate
-        self.init(bitrate: bitrate, indicatedBitrate: indicatedBitrate, observedBitrate: observedBitrate)
+        let numberOfDroppedVideoFrames = logEvent.numberOfDroppedVideoFrames
+        self.init(bitrate: bitrate, 
+                  indicatedBitrate: indicatedBitrate, 
+                  observedBitrate: observedBitrate,
+                  numberOfDroppedVideoFrames: numberOfDroppedVideoFrames)
     }
 }


### PR DESCRIPTION
### Description of the Changes

At MotorTrend, we have been using total number of dropped frames in our analytics. It would be nice to access them from PKPlaybackInfo, in Objective-C.

### CheckLists

- [*] changes have been done against master branch, and PR does not conflict

- [*] new unit / functional tests have been added (whenever applicable)
Not sure it makes sense to add a unit test for this, since this code simply passes the value from AVPlayerItemAccessLogEvent. We would need to mock one of those objects (kinda cumbersome no?). That said, I did install the branch via Cocoapods to make sure it compiles properly. No errors on my end.

- [*] test are passing in local environment 
Ditto from above comment.

- [*] Travis tests are passing (or test results are not worse than on master branch :))

- [*] Docs have been updated
I added a comment describing what the property does