### PR TITLE
Expose Creative ID and Advertiser Name

### DIFF
--- a/Classes/Events/EventsPayloads/PKAdInfo.swift
+++ b/Classes/Events/EventsPayloads/PKAdInfo.swift
@@ -52,9 +52,9 @@ import Foundation
     @objc public var podIndex: Int
     // The bitrate of the selected creative.
     @objc public var mediaBitrate: Int
-    // The CreativeID for the ad, taken from Google Interactive Media Ads
-    @objc public var creativeID: String
-    // The Advertiser Name for the ad, taken from Google Interactive Media Ads
+    // The CreativeId for the ad.
+    @objc public var creativeId: String
+    // The Advertiser Name for the ad.
     @objc public var advertiserName: String   
  
     /// returns the position type of the ad (pre, mid, post)
@@ -83,7 +83,7 @@ import Foundation
          isBumper: Bool,
          podIndex: Int,
          mediaBitrate: Int,
-         creativeID: String,
+         creativeId: String,
          advertiserName: String) {
         
         self.adDescription = adDescription
@@ -121,6 +121,8 @@ import Foundation
             "isBumper: \(isBumper)\n" +
             "podIndex: \(podIndex)\n" +
             "mediaBitrate: \(mediaBitrate)\n" +
-            "positionType: \(positionType)"
+            "positionType: \(positionType)" + 
+            "creativeId: \(creativeId)" +
+            "advertiserName: \(advertiserName)"
     }
 }

--- a/Classes/Events/EventsPayloads/PKAdInfo.swift
+++ b/Classes/Events/EventsPayloads/PKAdInfo.swift
@@ -101,7 +101,7 @@ import Foundation
         self.isBumper = isBumper
         self.podIndex = podIndex
         self.mediaBitrate = mediaBitrate
-        self.creativeID = creativeID
+        self.creativeId = creativeId
         self.advertiserName = advertiserName
     }
     

--- a/Classes/Events/EventsPayloads/PKAdInfo.swift
+++ b/Classes/Events/EventsPayloads/PKAdInfo.swift
@@ -52,7 +52,11 @@ import Foundation
     @objc public var podIndex: Int
     // The bitrate of the selected creative.
     @objc public var mediaBitrate: Int
-    
+    // The CreativeID for the ad, taken from Google Interactive Media Ads
+    @objc public var creativeID: String
+    // The Advertiser Name for the ad, taken from Google Interactive Media Ads
+    @objc public var advertiserName: String   
+ 
     /// returns the position type of the ad (pre, mid, post)
     @objc public var positionType: AdPositionType {
         if timeOffset > 0 {
@@ -78,7 +82,9 @@ import Foundation
          timeOffset: TimeInterval,
          isBumper: Bool,
          podIndex: Int,
-         mediaBitrate: Int) {
+         mediaBitrate: Int,
+         creativeID: String,
+         advertiserName: String) {
         
         self.adDescription = adDescription
         self.duration = adDuration
@@ -95,6 +101,8 @@ import Foundation
         self.isBumper = isBumper
         self.podIndex = podIndex
         self.mediaBitrate = mediaBitrate
+        self.creativeID = creativeID
+        self.advertiserName = advertiserName
     }
     
     public override var description: String {


### PR DESCRIPTION
### Description of the Changes

This is an enhancement to pass both the Creative ID and AdvertiserName from the Google Interactive Media Ads SDK through to PlayKit. There is a corresponding PR for the PlayKit IMA library that adds a similar change to the IMAExtensions.swift file allowing PKAdInfo to be constructed from a Google IMAAd object.

### CheckLists

- [*] changes have been done against master branch, and PR does not conflict

- [*] new unit / functional tests have been added (whenever applicable)
    None needed in my opinion.

- [*] test are passing in local environment 
    No tests added for this.

- [*] Travis tests are passing (or test results are not worse than on master branch :))

- [*] Docs have been updated
    There isn't much to do here since this is simply updating a property