### PR TITLE
Expose framerate in pk playback info

### DIFF
--- a/Classes/Events/EventsPayloads/PKPlaybackInfo.swift
+++ b/Classes/Events/EventsPayloads/PKPlaybackInfo.swift
@@ -21,7 +21,7 @@ import AVFoundation
     /// The throughput of the playback (download speed)
     public let observedBitrate: Double
     /// The playback framerate (optional since not all media is a video)
-    @ojbc public let framesPerSecond: Float? 
+    @objc public let framesPerSecond: Float? 
     
     init(bitrate: Double, 
          indicatedBitrate: Double, 
@@ -50,7 +50,7 @@ import AVFoundation
 
         for track in playerItem.tracks {
             if track.assetTrack.mediaType == AVMediaType.video {
-               framesPerSecond = track.currentVideoFramerate 
+               framesPerSecond = track.currentVideoFrameRate 
             }
         }
 

--- a/Classes/Events/EventsPayloads/PKPlaybackInfo.swift
+++ b/Classes/Events/EventsPayloads/PKPlaybackInfo.swift
@@ -20,14 +20,21 @@ import AVFoundation
     public let indicatedBitrate: Double
     /// The throughput of the playback (download speed)
     public let observedBitrate: Double
+    /// The playback framerate (optional since not all media is a video)
+    @ojbc public let framesPerSecond: Float? 
     
-    init(bitrate: Double, indicatedBitrate: Double, observedBitrate: Double) {
+    init(bitrate: Double, 
+         indicatedBitrate: Double, 
+         observedBitrate: Double,
+         framesPerSecond: Float?) {
         self.bitrate = bitrate
         self.indicatedBitrate = indicatedBitrate
         self.observedBitrate = observedBitrate
+        self.framesPerSecond = framesPerSecond
     }
     
-    convenience init(logEvent: AVPlayerItemAccessLogEvent) {
+    convenience init(logEvent: AVPlayerItemAccessLogEvent, 
+                     playerItem: AVPlayerItem) {
         let bitrate: Double
         if logEvent.segmentsDownloadedDuration > 0 {
             // bitrate is equal to:
@@ -38,6 +45,18 @@ import AVFoundation
         }
         let indicatedBitrate = logEvent.indicatedBitrate
         let observedBitrate = logEvent.observedBitrate
-        self.init(bitrate: bitrate, indicatedBitrate: indicatedBitrate, observedBitrate: observedBitrate)
+
+        var framesPerSecond: Float?
+
+        for track in playerItem.tracks {
+            if track.assetTrack.mediaType == AVMediaType.video {
+               framesPerSecond = track.currentVideoFramerate 
+            }
+        }
+
+        self.init(bitrate: bitrate, 
+                  indicatedBitrate: indicatedBitrate, 
+                  observedBitrate: observedBitrate,
+                  framesPerSecond: framesPerSecond)
     }
 }

--- a/Classes/Events/EventsPayloads/PKPlaybackInfo.swift
+++ b/Classes/Events/EventsPayloads/PKPlaybackInfo.swift
@@ -21,12 +21,12 @@ import AVFoundation
     /// The throughput of the playback (download speed)
     public let observedBitrate: Double
     /// The playback framerate (optional since not all media is a video)
-    @objc public let framesPerSecond: Float? 
+    @objc public let framesPerSecond: Float 
     
     init(bitrate: Double, 
          indicatedBitrate: Double, 
          observedBitrate: Double,
-         framesPerSecond: Float?) {
+         framesPerSecond: Float) {
         self.bitrate = bitrate
         self.indicatedBitrate = indicatedBitrate
         self.observedBitrate = observedBitrate
@@ -46,7 +46,7 @@ import AVFoundation
         let indicatedBitrate = logEvent.indicatedBitrate
         let observedBitrate = logEvent.observedBitrate
 
-        var framesPerSecond: Float?
+        var framesPerSecond: Float
 
         for track in playerItem.tracks {
             if track.assetTrack.mediaType == AVMediaType.video {

--- a/Classes/Events/EventsPayloads/PKPlaybackInfo.swift
+++ b/Classes/Events/EventsPayloads/PKPlaybackInfo.swift
@@ -46,7 +46,7 @@ import AVFoundation
         let indicatedBitrate = logEvent.indicatedBitrate
         let observedBitrate = logEvent.observedBitrate
 
-        var framesPerSecond: Float
+        var framesPerSecond: Float = 0
 
         for track in playerItem.tracks {
             if track.assetTrack.mediaType == AVMediaType.video {

--- a/Classes/Events/EventsPayloads/PKPlaybackInfo.swift
+++ b/Classes/Events/EventsPayloads/PKPlaybackInfo.swift
@@ -20,7 +20,7 @@ import AVFoundation
     public let indicatedBitrate: Double
     /// The throughput of the playback (download speed)
     public let observedBitrate: Double
-    /// The playback framerate (optional since not all media is a video)
+    /// The playback framerate (this value is zero if it is not reported)
     @objc public let framesPerSecond: Float 
     
     init(bitrate: Double, 

--- a/Classes/Player/AVPlayerEngine/AVPlayerEngine+Observation.swift
+++ b/Classes/Player/AVPlayerEngine/AVPlayerEngine+Observation.swift
@@ -74,7 +74,9 @@ extension AVPlayerEngine {
                 PKLog.verbose("event log:\n event log: averageAudioBitrate - \(lastEvent.averageAudioBitrate)\n event log: averageVideoBitrate - \(lastEvent.averageVideoBitrate)\n event log: indicatedAverageBitrate - \(lastEvent.indicatedAverageBitrate)\n event log: indicatedBitrate - \(lastEvent.indicatedBitrate)\n event log: observedBitrate - \(lastEvent.observedBitrate)\n event log: observedMaxBitrate - \(lastEvent.observedMaxBitrate)\n event log: observedMinBitrate - \(lastEvent.observedMinBitrate)\n event log: switchBitrate - \(lastEvent.switchBitrate)")
             }
             
-            self.post(event: PlayerEvent.PlaybackInfo(playbackInfo: PKPlaybackInfo(logEvent: lastEvent)))
+            self.post(event: PlayerEvent
+                             .PlaybackInfo(playbackInfo: PKPlaybackInfo(logEvent: lastEvent,
+                                                                        playerItem: playerItem)))
             if self.lastIndicatedBitrate != lastEvent.indicatedBitrate {
                 self.lastIndicatedBitrate = lastEvent.indicatedBitrate
                 self.post(event: PlayerEvent.VideoTrackChanged(bitrate: lastEvent.indicatedBitrate))


### PR DESCRIPTION
### Description of the Changes

Please add a detailed description of the change, wether it's an enhancement or a bugfix.
If the PR is related to an open issue please link to it.

This is an enhancement to add frame rate reporting to the standard PlayKit Playback Info.

### CheckLists

- [*] changes have been done against master branch, and PR does not conflict
- [*] new unit / functional tests have been added (whenever applicable)
- [*] test are passing in local environment 

I don't believe tests are relevant for this additional item

- [*] Travis tests are passing (or test results are not worse than on master branch :))
- [*] Docs have been updated

I add a comment referencing the new frames per second property