### PR TITLE
FEM-2463 Audio track language isn't added to KAVA view events at beginning

### DIFF
--- a/Classes/Player/AVPlayerEngine/AVPlayerEngine+Observation.swift
+++ b/Classes/Player/AVPlayerEngine/AVPlayerEngine+Observation.swift
@@ -327,8 +327,7 @@ extension AVPlayerEngine {
         }
         // handle audio selection mode, default is to let AVPlayer decide.
         switch trackSelection.audioSelectionMode {
-        case .off: break
-        case .auto:
+        case .off, .auto:
             handleAutoMode(for: tracks.audioTracks)
         case .selection:
             handleSelectionMode(for: tracks.audioTracks, language: trackSelection.audioSelectionLanguage)


### PR DESCRIPTION

### Description of the Changes

There is no off state for audio tracks, it should default to auto.
