### PR TITLE
FEM-2501: Allow using external FairPlay DRM servers

### DIFF
--- a/Classes/FairPlayDRM/FPSLicenseHelper.swift
+++ b/Classes/FairPlayDRM/FPSLicenseHelper.swift
@@ -14,7 +14,7 @@ import AVFoundation
 import SwiftyJSON
 
 @objc public protocol FairPlayLicenseProvider {
-    @objc func performLicenseRequest(spc: Data, requestParams: PKRequestParams,
+    @objc func getLicense(spc: Data, requestParams: PKRequestParams,
                                      callback: @escaping (_ ckc: Data?, _ offlineDuration: TimeInterval, _ error: Error?) -> Void)
 }
 
@@ -27,7 +27,7 @@ class KalturaFairPlayLicenseProvider: FairPlayLicenseProvider {
     
     static let sharedInstance = KalturaFairPlayLicenseProvider()
     
-    func performLicenseRequest(spc: Data, requestParams: PKRequestParams, callback: @escaping (Data?, TimeInterval, Error?) -> Void) {
+    func getLicense(spc: Data, requestParams: PKRequestParams, callback: @escaping (Data?, TimeInterval, Error?) -> Void) {
         var request = URLRequest(url: requestParams.url)
         if let headers = requestParams.headers {
             for (header, value) in headers {
@@ -35,6 +35,8 @@ class KalturaFairPlayLicenseProvider: FairPlayLicenseProvider {
             }
         }
         
+        // If a specific content-type was requested by the adapter, use it. 
+        // Otherwise, the uDRM requires application/octet-stream.
         if request.value(forHTTPHeaderField: "Content-Type") == nil {
             request.addValue("application/octet-stream", forHTTPHeaderField: "Content-Type")
         }
@@ -107,7 +109,7 @@ class FPSLicenseHelper {
         
         let licenseProvider = self.params?.licenseProvider ?? KalturaFairPlayLicenseProvider.sharedInstance
 
-        licenseProvider.performLicenseRequest(spc: spcData, 
+        licenseProvider.getLicense(spc: spcData, 
                                                requestParams: requestParams) { (ckc, duration, error) in
                                                 
                                                 guard let ckc = ckc else {

--- a/Classes/FairPlayDRM/FPSLicenseHelper.swift
+++ b/Classes/FairPlayDRM/FPSLicenseHelper.swift
@@ -22,7 +22,7 @@ class KalturaFairPlayLicenseProvider: FairPlayLicenseProvider {
     
     static let sharedInstance = KalturaFairPlayLicenseProvider()
     
-    func getLicense(spc: Data, requestParams: PKRequestParams, callback: @escaping (Data?, TimeInterval, Error?) -> Void) {
+    func getLicense(spc: Data, assetId: String, requestParams: PKRequestParams, callback: @escaping (Data?, TimeInterval, Error?) -> Void) {
         var request = URLRequest(url: requestParams.url)
         if let headers = requestParams.headers {
             for (header, value) in headers {
@@ -93,7 +93,7 @@ class FPSLicenseHelper {
         self.dataStore = dataStore
     }
     
-    func performCKCRequest(_ spcData: Data, url: URL, callback: @escaping (FPSLicense?, Error?) -> Void) {
+    func performCKCRequest(_ spcData: Data, assetId: String, url: URL, callback: @escaping (FPSLicense?, Error?) -> Void) {
         
         
         var requestParams = PKRequestParams(url: url, headers: nil)
@@ -104,7 +104,7 @@ class FPSLicenseHelper {
         
         let licenseProvider = self.params?.licenseProvider ?? KalturaFairPlayLicenseProvider.sharedInstance
 
-        licenseProvider.getLicense(spc: spcData, 
+        licenseProvider.getLicense(spc: spcData, assetId: assetId,
                                                requestParams: requestParams) { (ckc, duration, error) in
                                                 
                                                 guard let ckc = ckc else {
@@ -164,7 +164,7 @@ class FPSLicenseHelper {
             guard let spcData = spcData else { return }
             
             // Send SPC to Key Server and obtain CKC
-            self.performCKCRequest(spcData, url: params.url) { (license, error) in
+            self.performCKCRequest(spcData, assetId: assetId, url: params.url) { (license, error) in
                 guard let license = license else {
                     request.processContentKeyResponseError(error)
                     done(error)

--- a/Classes/FairPlayDRM/FPSLicenseHelper.swift
+++ b/Classes/FairPlayDRM/FPSLicenseHelper.swift
@@ -13,11 +13,6 @@ import Foundation
 import AVFoundation
 import SwiftyJSON
 
-@objc public protocol FairPlayLicenseProvider {
-    @objc func getLicense(spc: Data, requestParams: PKRequestParams,
-                                     callback: @escaping (_ ckc: Data?, _ offlineDuration: TimeInterval, _ error: Error?) -> Void)
-}
-
 struct KalturaLicenseResponseContainer: Codable {
     var ckc: String?
     var persistence_duration: TimeInterval?

--- a/Classes/FairPlayDRM/FPSLicenseHelper.swift
+++ b/Classes/FairPlayDRM/FPSLicenseHelper.swift
@@ -13,7 +13,7 @@ import Foundation
 import AVFoundation
 import SwiftyJSON
 
-@objc public protocol FPSLicenseRequestDelegate {
+@objc public protocol FairPlayLicenseProvider {
     @objc func performLicenseRequest(spc: Data, requestParams: PKRequestParams,
                                      callback: @escaping (_ ckc: Data?, _ offlineDuration: TimeInterval, _ error: Error?) -> Void)
 }
@@ -23,9 +23,9 @@ struct KalturaLicenseResponseContainer: Codable {
     var persistence_duration: TimeInterval?
 }
 
-class KalturaFPSLicenseRequestDelegate: FPSLicenseRequestDelegate {
+class KalturaFairPlayLicenseProvider: FairPlayLicenseProvider {
     
-    static let sharedInstance = KalturaFPSLicenseRequestDelegate()
+    static let sharedInstance = KalturaFairPlayLicenseProvider()
     
     func performLicenseRequest(spc: Data, requestParams: PKRequestParams, callback: @escaping (Data?, TimeInterval, Error?) -> Void) {
         var request = URLRequest(url: requestParams.url)
@@ -50,7 +50,7 @@ class KalturaFPSLicenseRequestDelegate: FPSLicenseRequestDelegate {
                 PKLog.debug("Got response in \(endTime-startTime) sec")
                 
                 guard let data = data else {
-                    callback(nil, 0, NSError(domain: "KalturaFPSLicenseRequestDelegate", code: 1, userInfo: nil))
+                    callback(nil, 0, NSError(domain: "KalturaFairPlayLicenseProvider", code: 1, userInfo: nil))
                     return
                 }
                 
@@ -105,9 +105,9 @@ class FPSLicenseHelper {
             requestParams = adapter.adapt(requestParams: requestParams)
         }
         
-        let fpsDelegate = self.params?.requestDelegate ?? KalturaFPSLicenseRequestDelegate.sharedInstance
+        let licenseProvider = self.params?.licenseProvider ?? KalturaFairPlayLicenseProvider.sharedInstance
 
-        fpsDelegate.performLicenseRequest(spc: spcData, 
+        licenseProvider.performLicenseRequest(spc: spcData, 
                                                requestParams: requestParams) { (ckc, duration, error) in
                                                 
                                                 guard let ckc = ckc else {

--- a/Classes/FairPlayDRM/FPSUtils.swift
+++ b/Classes/FairPlayDRM/FPSUtils.swift
@@ -89,6 +89,11 @@ class FPSLicense: Codable {
         self.expiryDate = Date(timeIntervalSinceNow: offlineExpiry)
     }
     
+    init(ckc: Data, duration: TimeInterval) {
+        self.data = ckc
+        self.expiryDate = Date(timeIntervalSinceNow: duration)
+    }
+    
     init(legacyData: Data) {
         self.data = legacyData
         self.expiryDate = nil

--- a/Classes/Player/Media/PKMediaEntry.swift
+++ b/Classes/Player/Media/PKMediaEntry.swift
@@ -169,6 +169,6 @@ public class FairPlayDRMParams: DRMParams {
 }
 
 @objc public protocol FairPlayLicenseProvider {
-    @objc func getLicense(spc: Data, requestParams: PKRequestParams,
+    @objc func getLicense(spc: Data, assetId: String, requestParams: PKRequestParams,
                           callback: @escaping (_ ckc: Data?, _ offlineDuration: TimeInterval, _ error: Error?) -> Void)
 }

--- a/Classes/Player/Media/PKMediaEntry.swift
+++ b/Classes/Player/Media/PKMediaEntry.swift
@@ -160,7 +160,7 @@ fileprivate let durationKey = "duration"
 public class FairPlayDRMParams: DRMParams {
     @objc public var fpsCertificate: Data?
     
-    internal var requestDelegate: FPSLicenseRequestDelegate?
+    internal var licenseProvider: FairPlayLicenseProvider?
     
     @objc public init(licenseUri: String, scheme: Scheme, base64EncodedCertificate: String) {
         fpsCertificate = Data(base64Encoded: base64EncodedCertificate)

--- a/Classes/Player/Media/PKMediaEntry.swift
+++ b/Classes/Player/Media/PKMediaEntry.swift
@@ -160,6 +160,8 @@ fileprivate let durationKey = "duration"
 public class FairPlayDRMParams: DRMParams {
     @objc public var fpsCertificate: Data?
     
+    internal var requestDelegate: FPSLicenseRequestDelegate?
+    
     @objc public init(licenseUri: String, scheme: Scheme, base64EncodedCertificate: String) {
         fpsCertificate = Data(base64Encoded: base64EncodedCertificate)
         super.init(licenseUri: licenseUri, scheme: scheme)

--- a/Classes/Player/Media/PKMediaEntry.swift
+++ b/Classes/Player/Media/PKMediaEntry.swift
@@ -167,3 +167,8 @@ public class FairPlayDRMParams: DRMParams {
         super.init(licenseUri: licenseUri, scheme: scheme)
     }
 }
+
+@objc public protocol FairPlayLicenseProvider {
+    @objc func getLicense(spc: Data, requestParams: PKRequestParams,
+                          callback: @escaping (_ ckc: Data?, _ offlineDuration: TimeInterval, _ error: Error?) -> Void)
+}

--- a/Classes/Player/PKPlayerSettings.swift
+++ b/Classes/Player/PKPlayerSettings.swift
@@ -86,7 +86,7 @@ enum PlayerSettingsType {
     @objc public var contentRequestAdapter: PKRequestParamsAdapter?
     @objc public var licenseRequestAdapter: PKRequestParamsAdapter?
     
-    @objc public var fpsLicenseRequestDelegate: FPSLicenseRequestDelegate?
+    @objc public var fairPlayLicenseProvider: FairPlayLicenseProvider?
     
     @objc public func createCopy() -> PKPlayerSettings {
         let copy = PKPlayerSettings()

--- a/Classes/Player/PKPlayerSettings.swift
+++ b/Classes/Player/PKPlayerSettings.swift
@@ -86,6 +86,8 @@ enum PlayerSettingsType {
     @objc public var contentRequestAdapter: PKRequestParamsAdapter?
     @objc public var licenseRequestAdapter: PKRequestParamsAdapter?
     
+    @objc public var fpsLicenseRequestDelegate: FPSLicenseRequestDelegate?
+    
     @objc public func createCopy() -> PKPlayerSettings {
         let copy = PKPlayerSettings()
         copy.cea608CaptionsEnabled = self.cea608CaptionsEnabled

--- a/Classes/Player/PlayerController.swift
+++ b/Classes/Player/PlayerController.swift
@@ -346,14 +346,14 @@ fileprivate extension PlayerController {
         
         // Maybe update licenseRequestAdapter and fpsLicenseRequestDelegate in params
         let drmAdapter = self.settings.licenseRequestAdapter
-        let fpsDelegate = self.settings.fpsLicenseRequestDelegate
+        let licenseProvider = self.settings.fairPlayLicenseProvider
         
         if let drmData = mediaSource.drmData {
             for d in drmData {
                 d.requestAdapter = drmAdapter
                 
                 if let fps = d as? FairPlayDRMParams {
-                    fps.requestDelegate = fpsDelegate
+                    fps.licenseProvider = licenseProvider
                 }
             }
         }

--- a/Classes/Player/PlayerController.swift
+++ b/Classes/Player/PlayerController.swift
@@ -344,9 +344,17 @@ fileprivate extension PlayerController {
             mediaSource.contentRequestAdapter = adapter
         }
         
-        if let adapter = self.settings.licenseRequestAdapter, let drmData = mediaSource.drmData {
-            for p in drmData {
-                p.requestAdapter = adapter
+        // Maybe update licenseRequestAdapter and fpsLicenseRequestDelegate in params
+        let drmAdapter = self.settings.licenseRequestAdapter
+        let fpsDelegate = self.settings.fpsLicenseRequestDelegate
+        
+        if let drmData = mediaSource.drmData {
+            for d in drmData {
+                d.requestAdapter = drmAdapter
+                
+                if let fps = d as? FairPlayDRMParams {
+                    fps.requestDelegate = fpsDelegate
+                }
             }
         }
     }


### PR DESCRIPTION
Add FairPlayLicenseProvider. This protocol allows customizing the FairPlay license acquisition process in a way that PKRequestAdapter doesn't: instead of just modifying the URL or headers, the implementing code is responsible for issuing the request and parsing the reponse.

```swift
@objc public protocol FairPlayLicenseProvider {
    @objc func getLicense(spc: Data, requestParams: PKRequestParams,
                          callback: @escaping (_ ckc: Data?, _ offlineDuration: TimeInterval, _ error: Error?) -> Void)
}
```