### PR TITLE
FEM-2564 When replaying a video after the pre-roll has been played, the pre-roll is played again

### DIFF
--- a/Classes/Player/Ads/AdsDAIPlayerEngineWrapper.swift
+++ b/Classes/Player/Ads/AdsDAIPlayerEngineWrapper.swift
@@ -258,6 +258,11 @@ public class AdsDAIPlayerEngineWrapper: PlayerEngineWrapper, AdsPluginDelegate, 
         playPerformed = false
     }
     
+    public override func replay() {
+        super.replay()
+        adsPlugin.didRequestPlay(ofType: .play)
+    }
+    
     override public func seek(to time: TimeInterval) {
         let endTime = adsPlugin.streamTime(forContentTime: time)
         guard !adsPlugin.isAdPlaying else { return }


### PR DESCRIPTION
### Description of the Changes

Fixed Replay playing the pre-roll even though it was played.