### PR TITLE
FEM-2557: FairPlay: report error if offline duration is <= 0

### DIFF
--- a/Classes/FairPlayDRM/FPSLicenseHelper.swift
+++ b/Classes/FairPlayDRM/FPSLicenseHelper.swift
@@ -172,6 +172,14 @@ class FPSLicenseHelper {
                 }
                                 
                 if shouldPersist {
+                    
+                    if license.isExpired() {
+                        let error = FPSError.invalidLicenseDuration
+                        request.processContentKeyResponseError(error)
+                        done(error)
+                        return
+                    }
+                    
                     do {
                         let pck = try request.persistableContentKey(fromKeyVendorResponse: license.data, options: nil)
                         license.data = pck

--- a/Classes/FairPlayDRM/FPSUtils.swift
+++ b/Classes/FairPlayDRM/FPSUtils.swift
@@ -28,6 +28,7 @@ enum FPSError: Error {
     case invalidKeyRequest
     case invalidMediaFormat
     case persistenceNotSupported
+    case invalidLicenseDuration
 }
 
 enum FPSInternalError: Error {


### PR DESCRIPTION
If the FairPlay server has returned 0 as the offline duration, and the request required offline access, report an error.