### PR TITLE
FEM-2602 Support video gravity

### DIFF
--- a/Classes/Player/PlayerView.swift
+++ b/Classes/Player/PlayerView.swift
@@ -23,6 +23,21 @@ import AVFoundation
         }
     }
     
+    public override var contentMode: UIView.ContentMode {
+        didSet {
+            switch self.contentMode {
+            case .scaleAspectFill:
+                playerLayer.videoGravity = .resizeAspectFill
+            case .scaleAspectFit:
+                playerLayer.videoGravity = .resizeAspect
+            case .scaleToFill:
+                playerLayer.videoGravity = .resize
+            default:
+                playerLayer.videoGravity = .resizeAspect
+            }
+        }
+    }
+    
     var playerLayer: AVPlayerLayer {
         return self.layer as! AVPlayerLayer
     }


### PR DESCRIPTION
### Description of the Changes

Setting the video gravity through the PlayerView content mode.
Only three content modes are supported: AspectFill, AspectFit, ScaleToFill.
Others will default to AspectFit.