### PR TITLE
FEM-2356 Setting startTime 0 for media Live with DVR doesn't start from 0

### DIFF
--- a/Classes/Player/AVPlayerEngine/AVPlayerEngine+AssetLoading.swift
+++ b/Classes/Player/AVPlayerEngine/AVPlayerEngine+AssetLoading.swift
@@ -77,11 +77,7 @@ extension AVPlayerEngine {
                  */
                 let playerItem = AVPlayerItem(asset: newAsset.avAsset)
                 playerItem.preferredPeakBitRate = newAsset.playerSettings.network.preferredPeakBitRate
-                // set start position, position is valid and player is ready to play (will only work on change media).
-                if self.startPosition > 0 && self.status == .readyToPlay {
-                    self.currentPosition = self.startPosition
-                    self.startPosition = 0
-                }
+                
                 // add observers
                 self.removeObservers()
                 self.addObservers()

--- a/Classes/Player/AVPlayerEngine/AVPlayerEngine.swift
+++ b/Classes/Player/AVPlayerEngine/AVPlayerEngine.swift
@@ -42,6 +42,14 @@ public class AVPlayerEngine: AVPlayer {
     var tracksManager = TracksManager()
     static var observerContext = 0
     
+    var internalDuration: TimeInterval = 0.0 {
+        didSet {
+            if oldValue != internalDuration {
+                self.post(event: PlayerEvent.DurationChanged(duration: internalDuration))
+            }
+        }
+    }
+    
     var onEventBlock: ((PKEvent) -> Void)?
     
     public weak var view: PlayerView? {
@@ -84,6 +92,7 @@ public class AVPlayerEngine: AVPlayer {
             return time.isNaN ? 0 : time
         }
         set {
+            let duration = self.duration
             let value = newValue > duration ? duration : (newValue < 0 ? 0 : newValue)
             let newTime = self.rangeStart + CMTimeMakeWithSeconds(value, preferredTimescale: self.rangeStart.timescale)
             PKLog.debug("set currentPosition: \(CMTimeGetSeconds(newTime))")
@@ -124,7 +133,9 @@ public class AVPlayerEngine: AVPlayer {
         
         PKLog.verbose("get duration: \(result)")
         // in some rare cases duration can be nan, in that case we will return 0.
-        return result.isNaN ? 0.0 : result
+        let duration = result.isNaN ? 0.0 : result
+        internalDuration = duration
+        return duration
     }
     
     var isPlaying: Bool {

--- a/Classes/Player/AVPlayerEngine/AVPlayerEngine.swift
+++ b/Classes/Player/AVPlayerEngine/AVPlayerEngine.swift
@@ -92,6 +92,7 @@ public class AVPlayerEngine: AVPlayer {
             return time.isNaN ? 0 : time
         }
         set {
+            if newValue.isNaN { return }
             let duration = self.duration
             let value = newValue > duration ? duration : (newValue < 0 ? 0 : newValue)
             let newTime = self.rangeStart + CMTimeMakeWithSeconds(value, preferredTimescale: self.rangeStart.timescale)

--- a/Classes/Player/PlayerConfig.swift
+++ b/Classes/Player/PlayerConfig.swift
@@ -14,13 +14,17 @@ import Foundation
 @objc public class MediaConfig: NSObject {
 
     @objc public var mediaEntry: PKMediaEntry
-    @objc public var startTime: TimeInterval = 0
+    @objc public var startTime: TimeInterval = TimeInterval.nan
     
     @objc public override var description: String {
         return "Media config, mediaEntry: \(self.mediaEntry)\nstartTime: \(self.startTime)"
     }
     
-    @objc public init(mediaEntry: PKMediaEntry, startTime: TimeInterval = 0) {
+    @objc public init(mediaEntry: PKMediaEntry) {
+        self.mediaEntry = mediaEntry
+    }
+    
+    @objc public init(mediaEntry: PKMediaEntry, startTime: TimeInterval) {
         self.mediaEntry = mediaEntry
         self.startTime = startTime
     }


### PR DESCRIPTION
### Description of the Changes

Fixed start time for live with DVR.
Fixed the state when the start position is not set, to not start from 0 as a default value, cause this sets the Live with DVR media to start from 0 and not the live edge.