### PR TITLE
FEM-2694 Audio tracks is not being set when the text track is set to off mode and there are no text tracks.

### DIFF
--- a/Classes/Player/AVPlayerEngine/AVPlayerEngine+Observation.swift
+++ b/Classes/Player/AVPlayerEngine/AVPlayerEngine+Observation.swift
@@ -332,7 +332,7 @@ extension AVPlayerEngine {
         // handle text selection mode, default is to turn subtitles off.
         switch trackSelection.textSelectionMode {
         case .off:
-            guard let track = tracks.textTracks?.first(where: { $0.title == TracksManager.textOffDisplay && $0.language == nil }) else { return }
+            guard let track = tracks.textTracks?.first(where: { $0.title == TracksManager.textOffDisplay && $0.language == nil }) else { break }
             self.selectTrack(trackId: track.id)
         case .auto:
             handleAutoMode(for: tracks.textTracks)


### PR DESCRIPTION

### Description of the Changes

Fixed the case there are no text tracks, to enable the code to continue to the audio tracks.