### PR TITLE
FEM-2787 Crash upon destroying the player on versions up to iOS 11.3

### DIFF
--- a/Classes/Player/AVPlayerEngine/AVPlayerEngine.swift
+++ b/Classes/Player/AVPlayerEngine/AVPlayerEngine.swift
@@ -242,8 +242,13 @@ public class AVPlayerEngine: AVPlayer {
     
     deinit {
         PKLog.debug("\(String(describing: type(of: self))), was deinitialized")
-        // removes the observers only on deinit to prevent chances of being removed twice.
+        // Removes the observers only on deinit to prevent chances of being removed twice.
         self.removeObservers()
+        
+        // There is a crash with the release of the KVO observer on previous versions up to iOS 11.3.
+        if #available(iOS 11.3, *) {} else if let observer = assetStatusObservation {
+            removeObserver(observer, forKeyPath: "asset.status")
+        }
     }
     
     public func stop() {

--- a/Classes/Player/AVPlayerEngine/AVPlayerEngine.swift
+++ b/Classes/Player/AVPlayerEngine/AVPlayerEngine.swift
@@ -246,7 +246,9 @@ public class AVPlayerEngine: AVPlayer {
         self.removeObservers()
         
         // There is a crash with the release of the KVO observer on previous versions up to iOS 11.3.
-        if #available(iOS 11.3, *) {} else if let observer = assetStatusObservation {
+        if #available(iOS 11.3, *) {
+            // No need to do anything, from iOS 11.3 the bug was fixed and the KVO observer is released.
+        } else if let observer = assetStatusObservation {
             removeObserver(observer, forKeyPath: "asset.status")
         }
     }


### PR DESCRIPTION
### Description of the Changes

Added workaround code for a bug with the release of the KVO observer on devices with previous versions up to iOS 11.3.

Solves FEM-2787