### PR TITLE
FEC-9929 A pause event is sent upon stop to the player.

### DIFF
--- a/Classes/Player/AVPlayerEngine/AVPlayerEngine+Observation.swift
+++ b/Classes/Player/AVPlayerEngine/AVPlayerEngine+Observation.swift
@@ -223,8 +223,10 @@ extension AVPlayerEngine {
     private func handleRate() {
         PKLog.debug("player rate was changed, now: \(self.rate)")
         // When setting automaticallyWaitsToMinimizeStalling and shouldPlayImmediately, the player may be stalled and the rate will be changed to 0, player paused, by the AVPlayer. Therefor we are sending a paused event.
-        if self.rate == 0, self.currentState == .buffering || self.currentState == .ready {
-            self.post(event: PlayerEvent.Pause())
+        if let isPlaybackLikelyToKeepUp = self.currentItem?.isPlaybackLikelyToKeepUp, isPlaybackLikelyToKeepUp == false {
+            if self.rate == 0, self.currentState == .buffering || self.currentState == .ready {
+                self.post(event: PlayerEvent.Pause())
+            }
         }
     }
     


### PR DESCRIPTION
### Description of the Changes

Send a PlayerEvent Pause upon rate changed to 0 only if it was caused by the stalling situation.

Solves FEC-9929