### PR TITLE
FEC-9987 Seek to live edge is not performed if called prior setting the current item

### DIFF
--- a/Classes/Player/AVPlayerEngine/AVPlayerEngine+Observation.swift
+++ b/Classes/Player/AVPlayerEngine/AVPlayerEngine+Observation.swift
@@ -296,9 +296,14 @@ extension AVPlayerEngine {
         self.postStateChange(newState: newState, oldState: self.currentState)
         self.currentState = newState
         
-        // Update new current item with the text track styling which was set.
-        if let textTrackStyling = self.asset?.playerSettings.textTrackStyling {
+        // Update new current item with the text track styling which was set, when we have a currentItem.
+        if currentItem != nil, let textTrackStyling = self.asset?.playerSettings.textTrackStyling {
             self.updateTextTrackStyling(textTrackStyling)
+        }
+        
+        // If seek to live edge was triggered, perform it when we have a currentItem.
+        if currentItem != nil, seekToLiveEdgeTriggered {
+            self.seekToLiveEdge()
         }
     }
     

--- a/Classes/Player/AVPlayerEngine/AVPlayerEngine.swift
+++ b/Classes/Player/AVPlayerEngine/AVPlayerEngine.swift
@@ -41,6 +41,8 @@ public class AVPlayerEngine: AVPlayer {
     var currentState: PlayerState = PlayerState.idle
     var tracksManager = TracksManager()
     static var observerContext = 0
+    /// Indicates if a seek to live edge was triggered prior setting the current item
+    var seekToLiveEdgeTriggered = false
     
     var internalDuration: TimeInterval = 0.0 {
         didSet {
@@ -297,11 +299,15 @@ public class AVPlayerEngine: AVPlayer {
         }
     }
     
-    private func seekToLiveEdge() {
+    func seekToLiveEdge() {
         guard let currentItem = self.currentItem else {
-            PKLog.error("Current item is empty, can't seek to live edge.")
+            seekToLiveEdgeTriggered = true
+            PKLog.error("Current item is empty, postpond seek to live edge.")
             return
         }
+        
+        seekToLiveEdgeTriggered = false
+        PKLog.debug("Calculating seek to live edge")
         
         let seekableRanges = currentItem.seekableTimeRanges
         if seekableRanges.count > 0 {


### PR DESCRIPTION
### Description of the Changes

Call seek to live edge only when the current item is set and if triggered.

Fixed call too updateTextTrackStyling to be performed only when the current item is set and not called twice and performing the logic the first time for waste.

Solves FEC-9987