### PR TITLE
FEC-10151 Wrong VR entry

### DIFF
--- a/Classes/Player/Media/PKMediaEntry.swift
+++ b/Classes/Player/Media/PKMediaEntry.swift
@@ -47,8 +47,13 @@ fileprivate let durationKey = "duration"
         didSet {
             //creating media entry with the above sources
             let vrKey = "360"
-            if let mediaTags = self.tags, mediaTags.contains(vrKey) {
-                self.vrData = VRData()
+            if let mediaTags = self.tags {
+                for tag in mediaTags.components(separatedBy: ",") {
+                    if tag.equals(vrKey) {
+                        self.vrData = VRData()
+                        break
+                    }
+                }
             }
         }
     }


### PR DESCRIPTION

### Description of the Changes

Fixed, creating a VR Data only when a tag is exactly 360, from the available tags that are returned.

Solves FEC-10151