### PR TITLE
FEC-10193 Crash on tvOS, KVO not removed

### DIFF
--- a/Classes/Player/AVPlayerEngine/AVPlayerEngine.swift
+++ b/Classes/Player/AVPlayerEngine/AVPlayerEngine.swift
@@ -248,9 +248,10 @@ public class AVPlayerEngine: AVPlayer {
         // Removes the observers only on deinit to prevent chances of being removed twice.
         self.removeObservers()
         
-        // There is a crash with the release of the KVO observer on previous versions up to iOS 11.3.
-        if #available(iOS 11.3, *) {
-            // No need to do anything, from iOS 11.3 the bug was fixed and the KVO observer is released.
+        // There is a crash with the release of the KVO observer on previous versions up to iOS 11.3 and tvOS 11.3.
+        // Which the release was not done automatically.
+        if #available(iOS 11.3, tvOS 11.3, *) {
+            // No need to do anything, from iOS 11.3 and tvOS 11.3 the bug was fixed and the KVO observer is released.
         } else if let observer = assetStatusObservation {
             removeObserver(observer, forKeyPath: "asset.status")
         }


### PR DESCRIPTION
### Description of the Changes

Added the validation for the tvOS version in addition to the iOS version, where it wasn't removed automatically.

Tested in our PlayKitAppleTVSample, with the Simulator for all tvOS available versions from 11.0 to 13.4.

Solves FEC-10193

**Crash:**
Terminating app due to uncaught exception 'NSInternalInconsistencyException', reason: 'An instance 0x610000253b30 of class PlayKit.PKAsset was deallocated while key value observers were still registered with it.

