### PR TITLE
FEC-10431 Support iOS 14 Xcode 12

### DIFF
--- a/Classes/FairPlayDRM/FPSContentKeySessionDelegate.swift
+++ b/Classes/FairPlayDRM/FPSContentKeySessionDelegate.swift
@@ -75,7 +75,15 @@ class FPSContentKeySessionDelegate: NSObject, AVContentKeySessionDelegate {
                 
         if helper.forceDownload, !(keyRequest is AVPersistableContentKeyRequest) {
             // We want to download but we're given a non-download request
-            keyRequest.respondByRequestingPersistableContentKeyRequest()
+            if #available(iOS 11.2, *) {
+                do {
+                    try keyRequest.respondByRequestingPersistableContentKeyRequestAndReturnError()
+                } catch {
+                    PKLog.error("RequestingPersistableContentKey encontered an error: \(error)")
+                }
+            } else {
+                keyRequest.respondByRequestingPersistableContentKeyRequest()
+            }
             return
         }
         

--- a/Classes/Player/AVPlayerEngine/AVPlayerEngine+AssetLoading.swift
+++ b/Classes/Player/AVPlayerEngine/AVPlayerEngine+AssetLoading.swift
@@ -19,6 +19,9 @@ extension AVPlayerEngine {
         // When changing media (loading new asset) we want to reset isFirstReady, in order to receive `CanPlay` & `LoadedMetadata` accurately.
         self.isFirstReady = true
         self.lastIndicatedBitrate = 0
+        // Reset internalDuration in order to get an update of durationChanged.
+        // If the previous media had the same duration as the new media, the durationChange was not fired.
+        self.internalDuration = 0
         super.replaceCurrentItem(with: item)
     }
     

--- a/Classes/Player/AVPlayerEngine/AVPlayerEngine.swift
+++ b/Classes/Player/AVPlayerEngine/AVPlayerEngine.swift
@@ -120,7 +120,13 @@ public class AVPlayerEngine: AVPlayer {
             if newValue.isNaN { return }
             if newValue.isEqual(to: self.currentPosition) { return }
             let duration = self.duration
-            let value = newValue > duration ? duration : (newValue < 0 ? 0 : newValue)
+            var value = newValue > duration ? duration : (newValue < 0 ? 0 : newValue)
+            // Seeking to the duration in iOS 14 doesn't work
+            if #available(iOS 14.0, *) {
+                if value == duration {
+                    value -= 0.1
+                }
+            }
             let newTime = self.rangeStart + CMTimeMakeWithSeconds(value, preferredTimescale: self.rangeStart.timescale)
             PKLog.debug("set currentPosition: \(CMTimeGetSeconds(newTime))")
             super.seek(to: newTime, toleranceBefore: CMTime.zero, toleranceAfter: CMTime.zero) { [weak self] (isSeeked: Bool) in

--- a/Classes/Player/Tracks/TracksManager.swift
+++ b/Classes/Player/Tracks/TracksManager.swift
@@ -66,7 +66,8 @@ public class TracksManager: NSObject {
     }
     
     @objc public func currentAudioTrack(item: AVPlayerItem) -> String? {
-        if let group = item.asset.mediaSelectionGroup(forMediaCharacteristic: AVMediaCharacteristic.audible), let option = item.selectedMediaOption(in: group) {
+        if let group = item.asset.mediaSelectionGroup(forMediaCharacteristic: AVMediaCharacteristic.audible),
+           let option = item.currentMediaSelection.selectedMediaOption(in: group) {
             return self.audioTracks?.filter{($0.title == option.displayName)}.first?.id
         }
         return nil
@@ -75,7 +76,7 @@ public class TracksManager: NSObject {
     @objc public func currentTextTrack(item: AVPlayerItem) -> String? {
         if let group = item.asset.mediaSelectionGroup(forMediaCharacteristic: AVMediaCharacteristic.legible) {
             var displayName: String
-            if let option = item.selectedMediaOption(in: group) {
+            if let option = item.currentMediaSelection.selectedMediaOption(in: group) {
                 displayName = option.displayName
             } else {
                 displayName = TracksManager.textOffDisplay

--- a/PlayKit.podspec
+++ b/PlayKit.podspec
@@ -17,7 +17,7 @@ s.tvos.deployment_target = '9.0'
 
 s.subspec 'Core' do |sp|
     sp.source_files = 'Classes/**/*'
-    sp.dependency 'SwiftyJSON', '4.3.0'
+    sp.dependency 'SwiftyJSON', '5.0.0'
     sp.dependency 'XCGLogger', '7.0.0'
     sp.dependency 'KalturaNetKit', '~> 1.3'
     sp.dependency 'PlayKitUtils', '~> 0.4'

--- a/PlayKit.podspec
+++ b/PlayKit.podspec
@@ -19,8 +19,8 @@ s.subspec 'Core' do |sp|
     sp.source_files = 'Classes/**/*'
     sp.dependency 'SwiftyJSON', '5.0.0'
     sp.dependency 'XCGLogger', '7.0.0'
-    sp.dependency 'KalturaNetKit', '~> 1.3'
-    sp.dependency 'PlayKitUtils', '~> 0.4'
+    sp.dependency 'KalturaNetKit', '~> 1.4'
+    sp.dependency 'PlayKitUtils', '~> 0.5'
 end
 
 s.subspec 'WidevineClassic' do |ssp|

--- a/travis-build.sh
+++ b/travis-build.sh
@@ -8,6 +8,6 @@ else
   # Else just build the test app
   curl https://kaltura.github.io/fe-tools/ios/pod-app/create.sh | bash -s - "pod 'PlayKit', :path => '..'"
   cd HelloPod
-  pod install
+  pod install --repo-update
   xcodebuild -workspace HelloPod.xcworkspace -scheme HelloPod -sdk iphonesimulator
 fi


### PR DESCRIPTION
### Description of the Changes

* Fixed deprecated code accordingly. 
  - selectedMediaOption in the Tracks. 
  - from iOS 11.2 'respondByRequestingPersistableContentKeyRequest' changed to 'respondByRequestingPersistableContentKeyRequestAndReturnError'.
* Updated SwiftyJSON to v5.0.0 from 4.3.0
* Workaround for iOS 14 issue upon seeking to the duration when the seek is done with zero tolerance. 
  Bug reported to Apple (FB8602469).
* Updated dependency to the latest KalturaNetKit and PlayKitUtils.

Solves FEC-10431
