### PR TITLE
FEC-10922 Expose interface and methods to enable customisation of HTTP request headers for playback request

### DIFF
--- a/Classes/Network/KalturaPlaybackRequestAdapter.swift
+++ b/Classes/Network/KalturaPlaybackRequestAdapter.swift
@@ -61,3 +61,60 @@ import Foundation
         return from.data(using: .utf8)?.base64EncodedString() ?? ""
     }
 }
+
+
+@objc public class CustomHeadersRequestAdapter: NSObject, PKRequestParamsAdapter {
+    
+    var customHTTPHeaders: [String: String]?
+    
+    @objc public func addHeaders(_ headers:[String: String]) {
+        
+        if self.customHTTPHeaders == nil {
+            customHTTPHeaders = [:]
+        }
+        
+        for (key, value) in headers {
+            self.customHTTPHeaders?[key] = value
+        }
+    }
+    
+    
+    @objc public func addCustomHeader(key: String, value: String) {
+        self.customHTTPHeaders?[key] = value
+    }
+    
+    @objc public static func install(in player: Player, withAppName appName: String) {
+        let requestAdapter = CustomHeadersRequestAdapter()
+//        requestAdapter.sessionId = player.sessionId
+//        requestAdapter.applicationName = appName
+        player.settings.contentRequestAdapter = requestAdapter
+    }
+    
+    
+    public func updateRequestAdapter(with player: Player) {
+        
+    }
+    
+    public func adapt(requestParams: PKRequestParams) -> PKRequestParams {
+        var parameters = requestParams
+        
+        var newHeaders: [String: String] = [:]
+        
+        if let headers = parameters.headers {
+            newHeaders = headers
+        }
+        
+        
+        
+        return parameters
+    }
+    
+}
+//    public static func getPluginHeaders() -> [String : String] {
+//        let token: String = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpYXQiOjE1MTYyMzkwMjIsIndtdmVyIjoyLCJ3bWlkZm10IjoiYXNjaWkiLCJ3bWlkdHlwIjoxLCJ3bWlkbGVuIjo1MTIsIndtb3BpZCI6MzIsIndtaWQiOiIyOTIxNmRmY2M0ZTIifQ.MvauSiNAvboiswsCkwD9_LkpCGSKcrLWaIFUsn2B9uM"
+//
+//        var headers: [String: String] = [:]
+//        headers["Authorization"] = "Bearer " + token
+//
+//        return headers
+//    }

--- a/Classes/Network/KalturaPlaybackRequestAdapter.swift
+++ b/Classes/Network/KalturaPlaybackRequestAdapter.swift
@@ -63,58 +63,26 @@ import Foundation
 }
 
 
-@objc public class CustomHeadersRequestAdapter: NSObject, PKRequestParamsAdapter {
+@objc public class CustomHeadersRequestAdapter: KalturaPlaybackRequestAdapter {
     
-    var customHTTPHeaders: [String: String]?
+    @objc public var customHTTPHeaders: [String: String]?
     
-    @objc public func addHeaders(_ headers:[String: String]) {
+    public override func adapt(requestParams: PKRequestParams) -> PKRequestParams {
+        let parameters = super.adapt(requestParams: requestParams)
         
-        if self.customHTTPHeaders == nil {
-            customHTTPHeaders = [:]
+        if let customHeaders = self.customHTTPHeaders {
+            var newHeaders: [String: String] = [:]
+            if let headers = parameters.headers {
+                newHeaders = headers
+            }
+                        
+            for (key, value) in customHeaders {
+                newHeaders[key] = value
+            }
+            return PKRequestParams(url: parameters.url, headers: newHeaders)
         }
-        
-        for (key, value) in headers {
-            self.customHTTPHeaders?[key] = value
-        }
-    }
-    
-    
-    @objc public func addCustomHeader(key: String, value: String) {
-        self.customHTTPHeaders?[key] = value
-    }
-    
-    @objc public static func install(in player: Player, withAppName appName: String) {
-        let requestAdapter = CustomHeadersRequestAdapter()
-//        requestAdapter.sessionId = player.sessionId
-//        requestAdapter.applicationName = appName
-        player.settings.contentRequestAdapter = requestAdapter
-    }
-    
-    
-    public func updateRequestAdapter(with player: Player) {
-        
-    }
-    
-    public func adapt(requestParams: PKRequestParams) -> PKRequestParams {
-        var parameters = requestParams
-        
-        var newHeaders: [String: String] = [:]
-        
-        if let headers = parameters.headers {
-            newHeaders = headers
-        }
-        
-        
         
         return parameters
     }
     
 }
-//    public static func getPluginHeaders() -> [String : String] {
-//        let token: String = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpYXQiOjE1MTYyMzkwMjIsIndtdmVyIjoyLCJ3bWlkZm10IjoiYXNjaWkiLCJ3bWlkdHlwIjoxLCJ3bWlkbGVuIjo1MTIsIndtb3BpZCI6MzIsIndtaWQiOiIyOTIxNmRmY2M0ZTIifQ.MvauSiNAvboiswsCkwD9_LkpCGSKcrLWaIFUsn2B9uM"
-//
-//        var headers: [String: String] = [:]
-//        headers["Authorization"] = "Bearer " + token
-//
-//        return headers
-//    }

--- a/Classes/Network/KalturaPlaybackRequestAdapter.swift
+++ b/Classes/Network/KalturaPlaybackRequestAdapter.swift
@@ -62,15 +62,14 @@ import Foundation
     }
 }
 
-
-@objc public class CustomHeadersRequestAdapter: KalturaPlaybackRequestAdapter {
+@objc public class CustomPlaybackRequestAdapter: KalturaPlaybackRequestAdapter {
     
-    @objc public var customHTTPHeaders: [String: String]?
+    @objc public var httpHeaders: [String: String]?
     
     public override func adapt(requestParams: PKRequestParams) -> PKRequestParams {
         let parameters = super.adapt(requestParams: requestParams)
         
-        if let customHeaders = self.customHTTPHeaders {
+        if let customHeaders = self.httpHeaders {
             var newHeaders: [String: String] = [:]
             if let headers = parameters.headers {
                 newHeaders = headers

--- a/Classes/Player/AVAsset/DefaultAssetHandler.swift
+++ b/Classes/Player/AVAsset/DefaultAssetHandler.swift
@@ -47,8 +47,8 @@ class DefaultAssetHandler: AssetHandler {
         
         var headers: [String: String] = [:]
         
-        if let playbackHeaders = mediaSource.playbackHeaders {
-            headers = playbackHeaders
+        if let playbackRequestHeaders = mediaSource.playbackRequestHeaders {
+            headers = playbackRequestHeaders
         }
         
         headers["User-Agent"] = PlayKitManager.userAgent

--- a/Classes/Player/AVAsset/DefaultAssetHandler.swift
+++ b/Classes/Player/AVAsset/DefaultAssetHandler.swift
@@ -45,7 +45,13 @@ class DefaultAssetHandler: AssetHandler {
             return
         }
         
-        let headers = ["User-Agent": PlayKitManager.userAgent]
+        var headers: [String: String] = [:]
+        
+        if let playbackHeaders = mediaSource.playbackHeaders {
+            headers = playbackHeaders
+        }
+        
+        headers["User-Agent"] = PlayKitManager.userAgent
         let cookies = HTTPCookieStorage.shared.cookies
         let assetOptions = ["AVURLAssetHTTPHeaderFieldsKey": headers, "AVURLAssetHTTPCookiesKey": cookies as Any] as [String : Any]
         

--- a/Classes/Player/Media/PKMediaSource.swift
+++ b/Classes/Player/Media/PKMediaSource.swift
@@ -87,7 +87,7 @@ fileprivate let formatTypeKey: String = "sourceType"
         return contentUrl
     }
     
-    public var playbackHeaders: [String: String]? {
+    public var playbackRequestHeaders: [String: String]? {
         guard let contentUrl = self.contentUrl else { return nil }
         if let contentRequestAdapter = self.contentRequestAdapter {
             return contentRequestAdapter.adapt(requestParams: PKRequestParams(url: contentUrl, headers: nil)).headers

--- a/Classes/Player/Media/PKMediaSource.swift
+++ b/Classes/Player/Media/PKMediaSource.swift
@@ -87,6 +87,14 @@ fileprivate let formatTypeKey: String = "sourceType"
         return contentUrl
     }
     
+    public var playbackHeaders: [String: String]? {
+        guard let contentUrl = self.contentUrl else { return nil }
+        if let contentRequestAdapter = self.contentRequestAdapter {
+            return contentRequestAdapter.adapt(requestParams: PKRequestParams(url: contentUrl, headers: nil)).headers
+        }
+        return nil
+    }
+    
     @objc public convenience init (id: String) {
         self.init(id, contentUrl: nil)
     }


### PR DESCRIPTION
### Description of the Changes

Exposed interface and methods to enable customisation of HTTP request headers for playback request.
Applies for playlist/manifest URL and for .ts segments URLs

Solves FEC-10922

## How to use :
* KalturaPlayer
``` 
let playbackAdaptor = CustomPlaybackRequestAdapter()
playbackAdaptor.httpHeaders = ["Authorization": "Bearer 12345689"]
kalturaOTTPlayer.settings.contentRequestAdapter = playbackAdaptor

// Load media
kalturaOTTPlayer.loadMedia(options: mediaOptions) {}
```

* PlayKit
```
let playbackAdaptor = CustomPlaybackRequestAdapter()
playbackAdaptor.httpHeaders = ["Authorization": "Bearer 12345689"]
self.player.settings.contentRequestAdapter = playbackAdaptor
        
// Prepare the player
self.player.prepare(mediaConfig)
```