### PR TITLE
FEC-10536 An error is not returned in case a source could not be selected.

### DIFF
--- a/Classes/PKError.swift
+++ b/Classes/PKError.swift
@@ -22,6 +22,7 @@ enum PlayerError: PKError {
     case assetNotPlayable
     case playerItemFailed(rootError: NSError)
     case failed(rootError: NSError)
+    case missingMediaSource
     
     static let domain = "com.kaltura.playkit.error.player"
     
@@ -31,6 +32,7 @@ enum PlayerError: PKError {
         case .assetNotPlayable: return PKErrorCode.assetNotPlayable
         case .playerItemFailed: return PKErrorCode.playerItemFailed
         case .failed: return PKErrorCode.playerFailed
+        case .missingMediaSource: return PKErrorCode.missingMediaSource
         }
     }
     
@@ -40,6 +42,7 @@ enum PlayerError: PKError {
         case .assetNotPlayable: return "Can't use this AVAsset because it isn't playable"
         case .playerItemFailed: return "Player item failed to play"
         case .failed: return "Player failed, you can no longer use the player for playback and need to recreate it"
+        case .missingMediaSource: return "No playable source found for entry"
         }
     }
     
@@ -53,6 +56,7 @@ enum PlayerError: PKError {
         case .assetNotPlayable: return [:]
         case .playerItemFailed(let rootError): return [PKErrorKeys.RootErrorKey: rootError]
         case .failed(let rootError): return [PKErrorKeys.RootErrorKey: rootError]
+        case .missingMediaSource: return [:]
         }
     }
 }
@@ -230,6 +234,7 @@ public struct PKErrorKeys {
     @objc(PlayerItemFailed) public static let playerItemFailed = 7002
     @objc(PlayerFailed) public static let playerFailed = 7003
     @objc(MissingDependency) public static let missingDependency = 7004
+    @objc(MissingMediaSource) public static let missingMediaSource = 7005
     // PlayerErrorLog
     @objc(PlayerItemErrorLogEvent) public static let playerItemErrorLogEvent = 7100
     // PKPluginError

--- a/Classes/Player/PlayerController.swift
+++ b/Classes/Player/PlayerController.swift
@@ -383,7 +383,12 @@ class PlayerController: NSObject, Player {
         self.mediaSessionUUID = UUID()
         
         // get the preferred media source and post source selected event
-        guard let (selectedSource, handler) = SourceSelector.selectSource(from: mediaConfig.mediaEntry) else { return }
+        guard let (selectedSource, handler) = SourceSelector.selectSource(from: mediaConfig.mediaEntry) else {
+            PKLog.error("No playable source found for entry")
+            self.onEventBlock?(PlayerEvent.Error(error: PlayerError.missingMediaSource))
+            return
+        }
+        
         self.onEventBlock?(PlayerEvent.SourceSelected(mediaSource: selectedSource))
         self.selectedSource = selectedSource
         self.assetHandler = handler


### PR DESCRIPTION
Solves FEC-10536

Added error which will be send to message bus for cases if media source can not be selected.