### PR TITLE
FEC-11624 Update LocalAssetsManager prepareForDownload  API with @objc

### DIFF
--- a/Classes/Managers/LocalAssetsManager.swift
+++ b/Classes/Managers/LocalAssetsManager.swift
@@ -246,7 +246,7 @@ extension LocalAssetsManager {
     }
     
     /// Prepare a PKMediaEntry for download using AVAssetDownloadTask.
-    public func prepareForDownload(of mediaEntry: PKMediaEntry) -> (AVURLAsset, PKMediaSource)? {
+    @objc public func prepareForDownload(of mediaEntry: PKMediaEntry) -> (AVURLAsset, PKMediaSource)? {
         guard let source = getPreferredDownloadableMediaSource(for: mediaEntry) else { return nil }
         guard let url = source.contentUrl else { return nil }
         let avAsset = AVURLAsset(url: url)

--- a/Classes/Managers/LocalAssetsManager.swift
+++ b/Classes/Managers/LocalAssetsManager.swift
@@ -261,7 +261,7 @@ fileprivate class NullStore: LocalDataStore {
         return false
     }
     
-    public func remove(key: String) throws {
+    @objc public func remove(key: String) throws {
         PKLog.error("LocalDataStore not set")
     }
     


### PR DESCRIPTION
Solves FEC-11624

Update `LocalAssetsManager` added `@objc` to `repareForDownload(of mediaEntry: PKMediaEntry)`
