### PR TITLE
Fix protocol compiler warning

### DIFF
--- a/Classes/Managers/AppState/AppStateProvider.swift
+++ b/Classes/Managers/AppState/AppStateProvider.swift
@@ -11,7 +11,7 @@
 import Foundation
 
 /// The delegate of `AppStateProvider`, allows the delegate to inform on app state notifications.
-public protocol AppStateProviderDelegate: class {
+public protocol AppStateProviderDelegate: AnyObject {
     /// fire this delegate function when received observation event.
     /// for every observer with the same observation event process the on observe block.
     func appStateEventPosted(name: ObservationName)

--- a/Classes/Managers/TimeObserver.swift
+++ b/Classes/Managers/TimeObserver.swift
@@ -10,7 +10,7 @@
 
 import Foundation
 
-protocol TimeProvider: class {
+protocol TimeProvider: AnyObject {
     var currentTime: TimeInterval { get }
     var duration: TimeInterval { get }
 }

--- a/Classes/Player/Ads/AdsPlugin.swift
+++ b/Classes/Player/Ads/AdsPlugin.swift
@@ -24,12 +24,12 @@ public enum PlayType: CustomStringConvertible {
     }
 }
 
-public protocol AdsPluginDataSource : class {
+public protocol AdsPluginDataSource : AnyObject {
     /// The player's media config start time.
     var playAdsAfterTime: TimeInterval { get }
 }
 
-public protocol AdsPluginDelegate : class {
+public protocol AdsPluginDelegate : AnyObject {
     func adsPlugin(_ adsPlugin: AdsPlugin, loaderFailedWith error: String)
     func adsPlugin(_ adsPlugin: AdsPlugin, managerFailedWith error: String)
     func adsPlugin(_ adsPlugin: AdsPlugin, didReceive event: PKEvent)

--- a/Classes/Providers/MediaEntryProviderResponseDelegate.swift
+++ b/Classes/Providers/MediaEntryProviderResponseDelegate.swift
@@ -14,7 +14,7 @@ import KalturaNetKit
 //This protocol provides a way to use the response data of the requests are being sent by MediaEntryProvider.
 //For example the response of getPlaybackContext, or additional meta data.
 
-public protocol PKMediaEntryProviderResponseDelegate: class {
+public protocol PKMediaEntryProviderResponseDelegate: AnyObject {
     
     func providerGotResponse(sender: MediaEntryProvider?, response: Response) -> Void
 

--- a/PlayKit.podspec
+++ b/PlayKit.podspec
@@ -1,5 +1,5 @@
-# suffix = '.0000'   # Dev mode
-suffix = ''       # Release
+suffix = '.0000'   # Dev mode
+# suffix = ''       # Release
 
 Pod::Spec.new do |s|
 

--- a/PlayKit.podspec
+++ b/PlayKit.podspec
@@ -1,5 +1,5 @@
-suffix = '.0000'   # Dev mode
-# suffix = ''       # Release
+# suffix = '.0000'   # Dev mode
+suffix = ''       # Release
 
 Pod::Spec.new do |s|
 


### PR DESCRIPTION
Fix warning: 
`Using 'class' keyword to define a class-constrained protocol is deprecated; use 'AnyObject' instead`
`Replace 'class' with 'AnyObject'`