### PR TITLE
fix: remove the player view when destroy player

### DIFF
--- a/Classes/Player/AVPlayerEngine/AVPlayerEngine.swift
+++ b/Classes/Player/AVPlayerEngine/AVPlayerEngine.swift
@@ -353,6 +353,8 @@ public class AVPlayerEngine: AVPlayer {
     
     func destroy() {
         PKLog.verbose("Destroy player")
+        self.view?.removeFromSuperview()
+        self.view = nil
         self.onEventBlock = nil
         // removes app state observer
         AppStateSubject.shared.remove(observer: self)


### PR DESCRIPTION
### Description of the Changes

when call player.destroy().
the player view still not remove/release, like
```
player.destroy()
player = PlayKitManager.sharedInstance.loadPlayer(config: config)
playerView = PlayerView.createPlayerViewForPlayer(player)
```
if play the same video source in two player, the video can not play normally.

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment 
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
