### PR TITLE
fix: post seeking notification before initiating AVPlayer seek operation

### DIFF
--- a/Classes/Player/AVPlayerEngine/AVPlayerEngine.swift
+++ b/Classes/Player/AVPlayerEngine/AVPlayerEngine.swift
@@ -130,16 +130,17 @@ public class AVPlayerEngine: AVPlayer {
             }
             let newTime = self.rangeStart + CMTimeMakeWithSeconds(value, preferredTimescale: self.rangeStart.timescale)
             PKLog.debug("set currentPosition: \(CMTimeGetSeconds(newTime))")
+
+            self.post(event: PlayerEvent.Seeking(targetSeekPosition: CMTimeGetSeconds(newTime)))
             super.seek(to: newTime, toleranceBefore: CMTime.zero, toleranceAfter: CMTime.zero) { [weak self] (isSeeked: Bool) in
                 guard let self = self else { return }
                 if isSeeked {
                     self.post(event: PlayerEvent.Seeked())
                     PKLog.debug("seeked")
                 } else {
-                    PKLog.error("seek faild")
+                    PKLog.error("seek failed")
                 }
             }
-            self.post(event: PlayerEvent.Seeking(targetSeekPosition: CMTimeGetSeconds(newTime)))
         }
     }
     


### PR DESCRIPTION
### Description of the Changes

Moved the 'seeking' notification to precede the initiation of the AVPlayer seek operation. This change aims to mitigate potential edge cases where the 'seeking' operation could be erroneously called after the 'seeked' notification, ensuring a more accurate sequence of event notifications.

In our release builds, we found a problem where sometimes the 'seeked' event happens before the 'seeking' event. This happens right after we set up the player and try to move to a 'continue watching' position. We couldn't see this issue when we were debugging, but looking closer at the Play-Kit code, we think the issue might be because of the order we send out notifications. This update fixes that by making sure we send the 'seeking' notification before we start the seek. This should stop the 'seeked' event from showing up too early.

Also question about in case failed, are you expecting to do `seeked` event or some new event `seekFailed`

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment 
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
